### PR TITLE
New storage system, AccountService

### DIFF
--- a/lib/blocs/authentication/mappers/auth_status_state_mapper.dart
+++ b/lib/blocs/authentication/mappers/auth_status_state_mapper.dart
@@ -17,7 +17,7 @@ class AuthStatusStateMapper {
       status = AuthStatus.locked;
     }
 
-    if (settingsStorage.accountName.isEmpty || settingsStorage.privateKey == null) {
+    if (settingsStorage.accounts == null || settingsStorage.accounts!.isEmpty) {
       status = AuthStatus.emptyAccount;
     }
 

--- a/lib/datasource/local/account_service.dart
+++ b/lib/datasource/local/account_service.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+import 'package:equatable/equatable.dart';
+import 'package:seeds/datasource/local/settings_storage.dart';
+
+class Account extends Equatable {
+  String address;
+  String name;
+  Account(this.address, this.name);
+
+  Map<String, dynamic> toJson() {
+    return {
+      "address": address,
+      "name": name,
+    };
+  }
+
+  factory Account.fromJson(Map<String, dynamic> json) {
+    return Account(
+      json["address"],
+      json["name"],
+    );
+  }
+
+  static List<Account> listFromJson(String jsonString) {
+    final List items = json.decode(jsonString) as List;
+    return items.map((e) => Account.fromJson(e)).toList();
+  }
+
+  static String jsonFromList(List<Account> accounts) {
+    final res = json.encode(accounts);
+    print("json str: $res");
+    return res;
+  }
+
+  @override
+  List<Object?> get props => [name, address];
+}
+
+class AccountService {
+  Future<List<Account>> loadAccounts() async {
+    final accountString = settingsStorage.accounts ?? "[]";
+    return Account.listFromJson(accountString);
+  }
+
+  void saveAccounts(List<Account> accounts) {
+    settingsStorage.saveAccounts(Account.jsonFromList(accounts));
+  }
+
+  void addKey(String key) {}
+
+  Future<Account?> createAccount(String name, String privateKey) async {
+    if (privateKey.contains(",")) {
+      throw ArgumentError("illegal character in private key: ',': $privateKey");
+    }
+    Account? result = null;
+    final public = await publicKeyForPrivateKey(privateKey);
+    if (public != null) {
+      final account = Account(name, public);
+      final accounts = await loadAccounts();
+      if (!accounts.contains(account)) {
+        accounts.add(account);
+        saveAccounts(accounts);
+        result = account;
+      }
+      final privateKeys = await getPrivateKeys();
+      if (!privateKeys.contains(privateKey)) {
+        privateKeys.add(privateKey);
+        await savePrivateKeys(privateKeys);
+      }
+    }
+    return result;
+  }
+
+  Future<String?> publicKeyForPrivateKey(String privateKey) async {
+    // TODO(n13): replace with repo function
+    return "foo";
+  }
+
+  Future<List<String>> getPrivateKeys() async {
+    final privateKeyString = await settingsStorage.getPrivateKeysString();
+    if (privateKeyString != null) {
+      return privateKeyString.split(",");
+    } else {
+      return [];
+    }
+  }
+
+  Future<void> savePrivateKeys(List<String> privateKeys) async {
+    await settingsStorage.savePrivateKeys(privateKeys.join(","));
+  }
+}

--- a/lib/datasource/local/auth_service.dart
+++ b/lib/datasource/local/auth_service.dart
@@ -13,22 +13,16 @@ class AuthService {
   AuthDataModel createRandomPrivateKeyAndWords() {
     final words = _createRandom12Words();
 
-    return AuthDataModel(_createPrivateKeyFrom12Words(words), words);
+    return AuthDataModel(words);
   }
 
   /// Creates a private key/12 words pair. From words
   AuthDataModel createPrivateKeyFromWords(List<String> words) {
-    return AuthDataModel(_createPrivateKeyFrom12Words(words), words);
+    return AuthDataModel(words);
   }
 
   AuthDataModel privateKeyFromSeedsGlobalPassportWords(List<String> words) {
-    return AuthDataModel(createPrivateKeyFrom12WordsBip39(words), words);
-  }
-
-  /// Creates a private key from 12 words list
-  EOSPrivateKey _createPrivateKeyFrom12Words(List<String> words) {
-    assert(words.length == 12);
-    return EOSPrivateKey.fromSeed(words.join('-'));
+    return AuthDataModel(words);
   }
 
   /// Creates 12 random words Mnemonic.

--- a/lib/datasource/local/models/auth_data_model.dart
+++ b/lib/datasource/local/models/auth_data_model.dart
@@ -1,14 +1,10 @@
-import 'package:seeds/crypto/eosdart_ecc/eosdart_ecc.dart';
-
 class AuthDataModel {
-  final EOSPrivateKey eOSPrivateKey;
   final List<String> words;
+  String get wordsString => words.join(" ");
 
-  AuthDataModel(this.eOSPrivateKey, this.words);
+  AuthDataModel(this.words);
 
-  AuthDataModel.fromKeyAndWords(String key, this.words) : eOSPrivateKey = EOSPrivateKey.fromString(key);
-
-  AuthDataModel.fromKeyAndNoWords(String key)
-      : eOSPrivateKey = EOSPrivateKey.fromString(key),
-        words = [];
+  factory AuthDataModel.fromString(String words) {
+    return AuthDataModel(words.split(" "));
+  }
 }

--- a/lib/datasource/remote/api/eos_repo/eos_repository.dart
+++ b/lib/datasource/remote/api/eos_repo/eos_repository.dart
@@ -55,8 +55,9 @@ abstract class EosRepository {
     return transaction;
   }
 
+// TODO(n13): remove all EOS code - this is not functional
   EOSClient buildEosClient() => EOSClient(remoteConfigurations.activeEOSServerUrl.url!, 'v1',
-      privateKeys: [settingsStorage.privateKey ?? onboardingPrivateKey, cpuPrivateKey]);
+      privateKeys: [/*settingsStorage.privateKey ??*/ onboardingPrivateKey, cpuPrivateKey]);
 
   FutureOr<Result<T>> mapEosResponse<T>(dynamic response, Function modelMapper) {
     print('mapEosResponse - transaction id: ${response['transaction_id']}');

--- a/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_words_from_private_key_use_case.dart
@@ -7,15 +7,16 @@ class GetWordsFromPrivateKey {
   /// otherwise an empty list.
   /// Handles both passport and seeds light wallet style 12 words keys
   List<String> run() {
-    final String privateKey = settingsStorage.privateKey!;
+    // final String privateKey = settingsStorage.privateKey!;
 
-    final wordsString = settingsStorage.recoveryWords.firstWhere((item) {
-      final words = item.toWordList();
-      return GenerateKeyFromRecoveryWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey ||
-          GenerateKeyFromSeedsPassportWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey;
-    }, orElse: () => '');
+    // final wordsString = settingsStorage.recoveryWords.firstWhere((item) {
+    //   final words = item.toWordList();
+    //   return GenerateKeyFromRecoveryWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey ||
+    //       GenerateKeyFromSeedsPassportWordsUseCase().run(words).eOSPrivateKey.toString() == privateKey;
+    // }, orElse: () => '');
 
-    return wordsString.isNotEmpty ? wordsString.toWordList() : [];
+    // return wordsString.isNotEmpty ? wordsString.toWordList() : [];
+    return []; // TODO(n13): remove
   }
 }
 

--- a/lib/domain-shared/shared_use_cases/save_account_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/save_account_use_case.dart
@@ -1,3 +1,4 @@
+import 'package:seeds/datasource/local/account_service.dart';
 import 'package:seeds/datasource/local/models/auth_data_model.dart';
 import 'package:seeds/datasource/local/settings_storage.dart';
 import 'package:seeds/datasource/local/web_view_cache_service.dart';
@@ -6,7 +7,7 @@ import 'package:seeds/domain-shared/shared_use_cases/account_use_case.dart';
 class SaveAccountUseCase extends AccountUseCase {
   Future<void> run({required String accountName, required AuthDataModel authData}) async {
     final String oldAccountName = settingsStorage.accountName;
-    await settingsStorage.saveAccount(accountName, authData);
+    await AccountService().createAccount(accountName, authData.wordsString);
     await const WebViewCacheService().clearCache();
     await updateFirebaseToken(oldAccount: oldAccountName, newAccount: accountName);
   }

--- a/lib/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart
+++ b/lib/screens/authentication/import_key/interactor/viewmodels/import_key_bloc.dart
@@ -75,12 +75,8 @@ class ImportKeyBloc extends Bloc<ImportKeyEvent, ImportKeyState> {
       emit(
         ImportKeyStateMapper().mapResultsToState(
           currentState: state,
-          authData: AuthDataModel.fromKeyAndWords(event.privateKey, event.words),
+          authData: AuthDataModel(event.words),
           results: results,
-          alternateAuthData: event.alternatePrivateKey != null
-              ? AuthDataModel.fromKeyAndWords(event.alternatePrivateKey!, event.words)
-              : null,
-          alternateResults: alternateResults,
         ),
       );
     }
@@ -94,10 +90,8 @@ class ImportKeyBloc extends Bloc<ImportKeyEvent, ImportKeyState> {
 
   void _findAccountFromWords(FindAccountFromWords event, Emitter<ImportKeyState> emit) {
     final authData = GenerateKeyFromRecoveryWordsUseCase().run(state.userEnteredWords.values.toList());
-    final alternateAuthData = GenerateKeyFromSeedsPassportWordsUseCase().run(state.userEnteredWords.values.toList());
     add(FindAccountByKey(
-      privateKey: authData.eOSPrivateKey.toString(),
-      alternatePrivateKey: alternateAuthData.eOSPrivateKey.toString(),
+      privateKey: authData.words.join(" "),
       words: authData.words,
     ));
   }

--- a/lib/screens/authentication/sign_up/usecases/create_account_usecase.dart
+++ b/lib/screens/authentication/sign_up/usecases/create_account_usecase.dart
@@ -1,4 +1,5 @@
 import 'package:async/async.dart';
+import 'package:seeds/crypto/eosdart_ecc/eosdart_ecc.dart';
 import 'package:seeds/datasource/local/models/auth_data_model.dart';
 import 'package:seeds/datasource/remote/api/signup_repository.dart';
 import 'package:seeds/datasource/remote/firebase/firebase_user_repository.dart';
@@ -16,7 +17,8 @@ class CreateAccountUseCase {
       accountName: accountName,
       inviteSecret: inviteSecret,
       displayName: displayName,
-      privateKey: authData.eOSPrivateKey,
+      // TODO(n13): change to polkadot create account
+      privateKey: EOSPrivateKey.fromString("DISABLED - TODO change this to Polkadot"),
     );
 
     // Phone number is optional.

--- a/lib/screens/profile_screens/recovery_phrase/interactor/viewmodels/recovery_phrase_bloc.dart
+++ b/lib/screens/profile_screens/recovery_phrase/interactor/viewmodels/recovery_phrase_bloc.dart
@@ -7,8 +7,7 @@ part 'recovery_phrase_state.dart';
 
 class RecoveryPhraseBloc extends Bloc<RecoveryPhraseEvent, RecoveryPhraseState> {
   RecoveryPhraseBloc()
-      : super(RecoveryPhraseState.initial(AuthDataModel.fromKeyAndWords(
-          settingsStorage.privateKey!,
-          settingsStorage.recoveryWords,
+      : super(RecoveryPhraseState.initial(AuthDataModel.fromString(
+          "todo", // TODO(n13): get recovery words in here
         )));
 }

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:seeds/blocs/authentication/viewmodels/authentication_bloc.dart';
 import 'package:seeds/components/full_page_error_indicator.dart';
 import 'package:seeds/components/full_page_loading_indicator.dart';
-import 'package:seeds/datasource/local/settings_storage.dart';
+import 'package:seeds/datasource/local/account_service.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/navigation/navigation_service.dart';
 import 'package:seeds/screens/settings/components/biometric_enabled_dialog.dart';
@@ -81,7 +81,12 @@ class SettingsScreen extends StatelessWidget {
                           icon: const Icon(Icons.update),
                           title: context.loc.securityExportPrivateKeyTitle,
                           description: context.loc.securityExportPrivateKeyDescription,
-                          onTap: () => Share.share(settingsStorage.privateKey!),
+                          // TODO(n13): Fix share secret words
+                          onTap: () async {
+                            final pk = await AccountService().getPrivateKeys();
+                            // ignore: unawaited_futures
+                            Share.share(pk[0]);
+                          },
                         ),
                         BlocBuilder<SettingsBloc, SettingsState>(
                           buildWhen: (previous, current) => previous.hasNotification != current.hasNotification,

--- a/lib/screens/wallet/interactor/viewmodels/wallet_bloc.dart
+++ b/lib/screens/wallet/interactor/viewmodels/wallet_bloc.dart
@@ -20,6 +20,5 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
     final result = await GetUserProfileUseCase().run(settingsStorage.accountName);
     WalletState newState;
     emit(newState = UserAccountStateMapper().mapResultToState(state, result));
-    settingsStorage.saveCitizenshipStatus(newState.profile.status);
   }
 }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

From old to new

private key, words map to --> words (there's only words, no difference between keys)

public key -> derived from private key using AccountService

Any accounts access through AccountService, which stores to settings and loads from settings, and secure settings.

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

AccountService is responsible for the Account class, and private and public keys

This will also provide mappings between available private keys and accounts. 

current account shows which account is selected (currently only 1 account supported)

### 🙈 Screenshots

### 👯‍♀️ Paired with
