### PR TITLE
Feature/error messages

### DIFF
--- a/lib/datasource/remote/polkadot_api/polkadot_repository.dart
+++ b/lib/datasource/remote/polkadot_api/polkadot_repository.dart
@@ -267,7 +267,7 @@ class PolkadotRepository extends KeyRepository {
   Future<Result> createRecovery(GuardiansConfigModel guardians) async {
     print("create recovery: ${guardians.toJson()}");
     try {
-      final res = ExtrinsicsRepository(_polkawalletInit!.webView!).createRecovery(
+      final res = await ExtrinsicsRepository(_polkawalletInit!.webView!).createRecovery(
         address: accountService.currentAccount.address,
         guardians: guardians.guardianAddresses,
         threshold: guardians.threshold,
@@ -282,11 +282,11 @@ class PolkadotRepository extends KeyRepository {
   /// Removes user's guardians. User must Start from scratch.
   Future<Result> removeGuardians() async {
     try {
-      final res = ExtrinsicsRepository(_polkawalletInit!.webView!)
+      final res = await ExtrinsicsRepository(_polkawalletInit!.webView!)
           .removeRecovery(address: accountService.currentAccount.address);
       return Result.value(res);
-    } on Exception catch (e) {
-      return Result.error(e);
+    } on Exception catch (err) {
+      return Result.error(err);
     }
   }
 
@@ -306,47 +306,46 @@ class PolkadotRepository extends KeyRepository {
       print("getRecoveryConfig res: $res");
       GuardiansConfigModel guardiansModel;
       if (res != null) {
-        res['address'] = address;
         guardiansModel = GuardiansConfigModel.fromJson(res);
       } else {
         return Result.value(GuardiansConfigModel.empty());
       }
       return Result.value(guardiansModel);
     } catch (err) {
-      print(err.toString());
-      return Result.error(ErrorResult("Error Loading Guardians"));
+      print('getRecoveryConfig error: $err');
+      return Result.error(err);
     }
   }
 
   /// Ignore, only test.
-  Future<String?> testCreateRecovery() async {
-    print("execute testSendRecovery");
-    // mnemonic: someone course sketch usage whisper helmet juice oyster rebuild razor mobile announce
-    const acct_0 = "5FyG1HpMSce9As8Uju4rEQnL24LZ8QNFDaKiu5nQtX6CY6BH";
-    // mnemonic: dress teach unveil require supply move butter sort cruise divide nice account
-    const acct_1 = "5Ca9Sdw7dxUK62FGkKXSZPr8cjNLobuGAgXu6RCM14aKtz6T";
-    // mnemonic: slogan crime relief smile door make deliver staff lonely hello worry sure
-    const acct_2 = "5C8126sqGbCa3m7Bsg8BFQ4arwcG81Vbbwi34EznBovrv7Zf";
+  // Future<String?> testCreateRecovery() async {
+  //   print("execute testSendRecovery");
+  //   // mnemonic: someone course sketch usage whisper helmet juice oyster rebuild razor mobile announce
+  //   const acct_0 = "5FyG1HpMSce9As8Uju4rEQnL24LZ8QNFDaKiu5nQtX6CY6BH";
+  //   // mnemonic: dress teach unveil require supply move butter sort cruise divide nice account
+  //   const acct_1 = "5Ca9Sdw7dxUK62FGkKXSZPr8cjNLobuGAgXu6RCM14aKtz6T";
+  //   // mnemonic: slogan crime relief smile door make deliver staff lonely hello worry sure
+  //   const acct_2 = "5C8126sqGbCa3m7Bsg8BFQ4arwcG81Vbbwi34EznBovrv7Zf";
 
-    final keyPair = await getKeyPair(accountService.currentAccount.address);
+  //   final keyPair = await getKeyPair(accountService.currentAccount.address);
 
-    print("keyPair $keyPair");
+  //   print("keyPair $keyPair");
 
-    final publicKey = await getPublicKey(accountService.currentAccount.address);
+  //   final publicKey = await getPublicKey(accountService.currentAccount.address);
 
-    print("publicKey $publicKey");
+  //   print("publicKey $publicKey");
 
-    return ExtrinsicsRepository(_polkawalletInit!.webView!).createRecovery(
-      address: accountService.currentAccount.address,
-      guardians: [
-        acct_0,
-        acct_1,
-        acct_2,
-      ],
-      threshold: 2,
-      delayPeriod: GuardiansConfigModel.defaultDelayPeriod,
-    );
-  }
+  //   return ExtrinsicsRepository(_polkawalletInit!.webView!).createRecovery(
+  //     address: accountService.currentAccount.address,
+  //     guardians: [
+  //       acct_0,
+  //       acct_1,
+  //       acct_2,
+  //     ],
+  //     threshold: 2,
+  //     delayPeriod: GuardiansConfigModel.defaultDelayPeriod,
+  //   );
+  // }
 }
 
 // This code extracted from the SDK
@@ -394,6 +393,7 @@ class ExtrinsicsRepository {
       "",
     );
     final txInfo = TxInfoData('recovery', 'createRecovery', sender);
+
     guardians.sort();
 
     try {

--- a/lib/datasource/remote/polkadot_api/polkadot_repository.dart
+++ b/lib/datasource/remote/polkadot_api/polkadot_repository.dart
@@ -386,52 +386,6 @@ class SendTransactionHelper {
     }
   }
 
-  Future<String?> sendRecovery2() async {
-    final code = '''
-new Promise(async (resolve) => {
-    const unsubscribe = await api.tx.recovery.removeRecovery()
-      .signAndSend(keyring.getPair(address), ({ events = [], status, txHash }) => {
-        console.log(`Remove Recovery: Current status is \${status.type}`);
-  
-        if (status.isFinalized) {
-          var transactionSuccess = false
-
-          console.log(`Transaction included at blockHash \${status.asFinalized}`);
-          console.log(`Transaction hash \${txHash.toHex()}`);
-  
-          // Loop through Vec<EventRecord> to display all events
-          events.forEach(({ phase, event: { data, method, section } }) => {
-            console.log(`\t' \${phase}: \${section}.\${method}:: \${data}`);
-            if (section == "system" && method == "ExtrinsicFailed") {
-              transactionSuccess = false
-            } 
-            if (section == "system" && method == "ExtrinsicSuccess") {
-              transactionSuccess = true
-            }
-          });
-
-          console.log("unsubscribing from updates..")
-          unsubscribe()
-          // => 
-          // ' {"applyExtrinsic":1}: balances.Withdraw:: ["5HGZfBpqUUqGY7uRCYA6aRwnRHJVhrikn8to31GcfNcifkym",85795211]
-          // ' {"applyExtrinsic":1}: system.ExtrinsicFailed:: [{"module":{"index":10,"error":"0x04000000"}},{"weight":148937000,"class":"Normal","paysFee":"Yes"}]
-         
-          resolve({
-            events,
-            status,
-            txHash,
-            transactionSuccess,
-          })
-  
-        }
-      });
-  })
-    ''';
-    final res = await _webView.evalJavascript(code);
-    print("sendRecovery2 res: $res");
-    return res;
-  }
-
   Future<String?> sendCreateRecovery({
     required String address,
     required List<String> guardians,
@@ -444,7 +398,6 @@ new Promise(async (resolve) => {
     );
     final txInfo = TxInfoData('recovery', 'createRecovery', sender);
     guardians.sort();
-    print("sorted guards: $guardians");
 
     try {
       final hash = await signAndSend(

--- a/lib/datasource/remote/polkadot_api/polkadot_repository.dart
+++ b/lib/datasource/remote/polkadot_api/polkadot_repository.dart
@@ -281,11 +281,13 @@ class PolkadotRepository extends KeyRepository {
 
   /// Removes user's guardians. User must Start from scratch.
   Future<Result> removeGuardians() async {
-    final res =
-        ExtrinsicsRepository(_polkawalletInit!.webView!).removeRecovery(address: accountService.currentAccount.address);
-
-    /// Nik add error case
-    return Result.value(res);
+    try {
+      final res = ExtrinsicsRepository(_polkawalletInit!.webView!)
+          .removeRecovery(address: accountService.currentAccount.address);
+      return Result.value(res);
+    } on Exception catch (e) {
+      return Result.error(e);
+    }
   }
 
   Future<Result> getActiveRecovery() async {

--- a/lib/polkadot/sdk_0.4.8/lib/api/types/txInfoData.dart
+++ b/lib/polkadot/sdk_0.4.8/lib/api/types/txInfoData.dart
@@ -40,15 +40,13 @@ class TxSenderData {
   final String? address;
   final String? pubKey;
 
-  static TxSenderData fromJson(Map<String, dynamic> json) =>
-      _$TxSenderDataFromJson(json);
+  static TxSenderData fromJson(Map<String, dynamic> json) => _$TxSenderDataFromJson(json);
   Map<String, dynamic> toJson() => _$TxSenderDataToJson(this);
 }
 
 @JsonSerializable()
 class TxFeeEstimateResult extends _TxFeeEstimateResult {
-  static TxFeeEstimateResult fromJson(Map<String, dynamic> json) =>
-      _$TxFeeEstimateResultFromJson(json);
+  static TxFeeEstimateResult fromJson(Map<String, dynamic> json) => _$TxFeeEstimateResultFromJson(json);
   Map<String, dynamic> toJson() => _$TxFeeEstimateResultToJson(this);
 }
 

--- a/lib/polkadot/sdk_0.4.8/lib/service/webViewRunner.dart
+++ b/lib/polkadot/sdk_0.4.8/lib/service/webViewRunner.dart
@@ -216,6 +216,7 @@ class WebViewRunner {
         '  console.log(JSON.stringify({ path: "$method", data: res }));res;'
         '}).catch(function(err) {'
         '  console.log(JSON.stringify({ path: "log", data: {call: "$method", error: err.message} }));'
+        '  JSON.stringify({call: "$method", error: err.message });'
         '});';
     _web!.webViewController.evaluateJavascript(source: script);
 

--- a/lib/screens/profile_screens/guardians/guardians_tabs/components/my_guardians_view.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/components/my_guardians_view.dart
@@ -43,7 +43,10 @@ class MyGuardiansView extends StatelessWidget {
                     }),
               )));
 
-          if (state.myGuardians.length < 3 && !state.myGuardians.areGuardiansActive) {
+          /// Gery - areGuardiansActive does not seem to get set correctly after reset guardians.
+          /// So after reset, after adding the first guardian, the "add guardian" button then would not appear
+          ///
+          if (state.myGuardians.length < 9 /* &&  !state.myGuardians.areGuardiansActive*/) {
             items.add(ListTile(
                 title: const Text('Add Guardian'),
                 trailing: IconButton(

--- a/lib/screens/profile_screens/guardians/guardians_tabs/interactor/viewmodels/guardians_bloc.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/interactor/viewmodels/guardians_bloc.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:async/src/result/result.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:seeds/datasource/local/account_service.dart';
@@ -14,6 +13,7 @@ import 'package:seeds/screens/profile_screens/guardians/guardians_tabs/interacto
 import 'package:seeds/screens/profile_screens/guardians/guardians_tabs/interactor/usecases/init_guardians_usecase.dart';
 import 'package:seeds/screens/profile_screens/guardians/guardians_tabs/interactor/usecases/remove_guardian_usecase.dart';
 import 'package:seeds/screens/profile_screens/guardians/guardians_tabs/interactor/viewmodels/page_commands.dart';
+import 'package:seeds/utils/result_extension.dart';
 
 part 'guardians_event.dart';
 part 'guardians_state.dart';

--- a/lib/screens/wallet/components/tokens_cards/tokens_cards.dart
+++ b/lib/screens/wallet/components/tokens_cards/tokens_cards.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:seeds/blocs/rates/viewmodels/rates_bloc.dart';
 import 'package:seeds/components/dots_indicator.dart';
-import 'package:seeds/datasource/remote/polkadot_api/polkadot_repository.dart';
 import 'package:seeds/domain-shared/page_state.dart';
 import 'package:seeds/screens/wallet/components/tokens_cards/components/currency_info_card.dart';
 import 'package:seeds/screens/wallet/components/tokens_cards/interactor/viewmodels/token_balances_bloc.dart';
@@ -71,8 +70,8 @@ class _TokenCardsState extends State<TokenCards> with AutomaticKeepAliveClientMi
                       Expanded(
                           child: WalletButtons(
                               onPressed: () {
-                                print("testSendRecovery...");
-                                polkadotRepository.testCreateRecovery();
+                                print("testSendRecovery disabled...");
+                                //olkadotRepository.testCreateRecovery();
                               },
                               title: 'Send')),
                       const SizedBox(width: 16),


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Fixes #61 

Returning error results when polkadot errors occur. 

Tested.

One issue is somehow the keeping of the state doesn't work anymore. But that's unrelated to these changes. 

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

As discussed, each call we use - get guardians, init guardians, and reset guardians - returns a value result on success, and an error result on failure. 

Error messages are not user friendly but later we can use polkadot to look up error messages and format them nicely - the block explorers to that and it's very nice. So we can look up recovery.NotSortedException and get a nice explanatory string for it. But that's not for now.

Cleaned up some code
Removed some unused code
Commented out some test code
Small fixes

### 🙈 Screenshots


### 👯‍♀️ Paired with

