### PR TITLE
fix state when activating guardians

### DIFF
--- a/lib/screens/profile_screens/guardians/guardians_tabs/interactor/viewmodels/guardians_bloc.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/interactor/viewmodels/guardians_bloc.dart
@@ -116,13 +116,12 @@ class GuardiansBloc extends Bloc<GuardiansEvent, GuardiansState> {
 
     final Result result = await ActivateGuardiansUseCase().createRecovery(event.guards);
 
-    print("res $result");
-
     if (result.isValue) {
       emit(state.copyWith(
+        areGuardiansActive: true,
         actionButtonState: getActionButtonState(
           areGuardiansActive: true,
-          guardiansCount: state.myGuardians.delayPeriod,
+          guardiansCount: event.guards.length,
         ),
       ));
     } else {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Fixed state when activating guardians

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Two problems
- it was not setting the global areGuardiansActive flag - only for the button, so the button would show reset but the action would still try to create guardians
- guardians count was set to delay period..

### 🙈 Screenshots

_For all UI changes_

| description 1 | description 2 |
| --- | --- |
| img1 | img2 |

### 👯‍♀️ Paired with

_@github-handle or "nobody" if you did not pair._
