### PR TITLE
Feature/recover account settings item

### DIFF
--- a/lib/datasource/local/cache_repository.dart
+++ b/lib/datasource/local/cache_repository.dart
@@ -1,10 +1,6 @@
 import 'package:hashed/datasource/local/member_model_cache_item.dart';
 import 'package:hive/hive.dart';
 
-// Hive box names
-
-const String _proposalVotesBox = 'proposalVotesBox';
-const String _referendumsVotesBox = 'referendumsVotesBox';
 const String _membersBox = 'membersBox001';
 
 // Cache Repo

--- a/lib/screens/authentication/recover/recover_account_search/recover_account_search_screen.dart
+++ b/lib/screens/authentication/recover/recover_account_search/recover_account_search_screen.dart
@@ -50,7 +50,9 @@ class _RecoverAccountSearchScreenState extends State<RecoverAccountSearchScreen>
         },
         builder: (context, state) {
           return Scaffold(
-            appBar: AppBar(),
+            appBar: AppBar(
+              title: const Text("Recover Account"),
+            ),
             body: SafeArea(
               minimum: const EdgeInsets.all(horizontalEdgePadding),
               child: Stack(
@@ -60,9 +62,8 @@ class _RecoverAccountSearchScreenState extends State<RecoverAccountSearchScreen>
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
                         TextFormFieldCustom(
-                          maxLength: 12,
-                          counterText: null,
-                          labelText: context.loc.recoverAccountSearchTextFormTitle,
+                          maxLines: 2,
+                          labelText: "Enter Account Address",
                           controller: _keyController,
                           suffixIcon: QuadStateClipboardIconButton(
                             isChecked: state.isGuardianActive,
@@ -75,6 +76,7 @@ class _RecoverAccountSearchScreenState extends State<RecoverAccountSearchScreen>
                                 () => BlocProvider.of<RecoverAccountSearchBloc>(context).add(OnUsernameChanged(value)));
                           },
                         ),
+                        const Text("[TBD] This is not implemented yet"),
                         if (state.accountFound)
                           Container(
                             decoration: BoxDecoration(

--- a/lib/screens/settings/interactor/viewmodels/settings_bloc.dart
+++ b/lib/screens/settings/interactor/viewmodels/settings_bloc.dart
@@ -30,6 +30,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<SetUpInitialValues>(_setUpInitialValues);
     on<ShouldShowNotificationBadge>((event, emit) => emit(state.copyWith(hasNotification: event.value)));
     on<OnGuardiansCardTapped>(_onGuardiansCardTapped);
+    on<OnRecoverAccountTapped>(_onRecoverAccountTapped);
     on<OnExportPrivateKeyCardTapped>(
         (event, emit) => emit(state.copyWith(pageCommand: NavigateToRoute(Routes.exportPrivateKey))));
     on<OnPasscodePressed>(_onPasscodePressed);
@@ -66,6 +67,11 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       await FirebaseDatabaseGuardiansRepository().removeGuardianNotification(accountService.currentAccount.address);
     }
     emit(state.copyWith(navigateToGuardians: true));
+  }
+
+  Future<void> _onRecoverAccountTapped(OnRecoverAccountTapped event, Emitter<SettingsState> emit) async {
+    emit(state.copyWith()); //reset
+    emit(state.copyWith(navigateToRecoverAccount: true));
   }
 
   void _onPasscodePressed(OnPasscodePressed event, Emitter<SettingsState> emit) {

--- a/lib/screens/settings/interactor/viewmodels/settings_event.dart
+++ b/lib/screens/settings/interactor/viewmodels/settings_event.dart
@@ -40,6 +40,12 @@ class OnGuardiansCardTapped extends SettingsEvent {
   String toString() => 'OnGuardiansCardTapped';
 }
 
+class OnRecoverAccountTapped extends SettingsEvent {
+  const OnRecoverAccountTapped();
+  @override
+  String toString() => 'OnRecoverAccountTapped';
+}
+
 class OnPasscodePressed extends SettingsEvent {
   const OnPasscodePressed();
   @override

--- a/lib/screens/settings/interactor/viewmodels/settings_state.dart
+++ b/lib/screens/settings/interactor/viewmodels/settings_state.dart
@@ -16,6 +16,7 @@ class SettingsState extends Equatable {
   final bool? isSecurePasscode;
   final bool? isSecureBiometric;
   final bool shouldShowExportRecoveryPhrase;
+  final bool? navigateToRecoverAccount;
 
   const SettingsState({
     required this.pageState,
@@ -29,6 +30,7 @@ class SettingsState extends Equatable {
     this.isSecurePasscode,
     this.isSecureBiometric,
     required this.shouldShowExportRecoveryPhrase,
+    this.navigateToRecoverAccount,
   });
 
   @override
@@ -44,6 +46,7 @@ class SettingsState extends Equatable {
         isSecurePasscode,
         isSecureBiometric,
         shouldShowExportRecoveryPhrase,
+        navigateToRecoverAccount,
       ];
 
   SettingsState copyWith({
@@ -59,6 +62,7 @@ class SettingsState extends Equatable {
     bool? isSecureBiometric,
     GuardiansStatus? guardiansStatus,
     bool? shouldShowExportRecoveryPhrase,
+    bool? navigateToRecoverAccount,
   }) {
     return SettingsState(
       pageState: pageState ?? this.pageState,
@@ -68,6 +72,7 @@ class SettingsState extends Equatable {
       navigateToGuardians: navigateToGuardians,
       showLogoutButton: showLogoutButton ?? this.showLogoutButton,
       navigateToVerification: navigateToVerification,
+      navigateToRecoverAccount: navigateToRecoverAccount,
       currentChoice: currentChoice ?? this.currentChoice,
       isSecurePasscode: isSecurePasscode ?? this.isSecurePasscode,
       isSecureBiometric: isSecureBiometric ?? this.isSecureBiometric,

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -33,6 +33,10 @@ class SettingsScreen extends StatelessWidget {
               listener: (context, _) => NavigationService.of(context).navigateTo(Routes.guardianTabs),
             ),
             BlocListener<SettingsBloc, SettingsState>(
+              listenWhen: (_, current) => current.navigateToRecoverAccount != null,
+              listener: (context, _) => NavigationService.of(context).navigateTo(Routes.recoverAccountSearch),
+            ),
+            BlocListener<SettingsBloc, SettingsState>(
               listenWhen: (_, current) => current.navigateToVerification != null,
               listener: (context, _) {
                 BlocProvider.of<SettingsBloc>(context).add(const ResetNavigateToVerification());
@@ -92,8 +96,7 @@ class SettingsScreen extends StatelessWidget {
                         SettingsCard(
                           icon: const Icon(Icons.update),
                           title: "Export Private Key",
-                          description: context.loc.securityExportPrivateKeyDescription,
-                          // TODO(n13): Fix share secret words
+                          description: "Export your private key so you can easily recover and access your account.",
                           onTap: () async {
                             BlocProvider.of<SettingsBloc>(context).add(const OnExportPrivateKeyCardTapped());
                           },
@@ -107,6 +110,16 @@ class SettingsScreen extends StatelessWidget {
                             );
                           },
                         ),
+                        SettingsCard(
+                          icon: const Icon(Icons.shield),
+                          title: "Recover Account",
+                          description: "Recover an account with the help of the guardians set for that account.",
+                          // TODO(n13): Fix share secret words
+                          onTap: () async {
+                            BlocProvider.of<SettingsBloc>(context).add(const OnRecoverAccountTapped());
+                          },
+                        ),
+
                         if (state.shouldShowExportRecoveryPhrase)
                           SettingsCard(
                             icon: const Icon(Icons.insert_drive_file),


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Recover account goes in settings - added an entry for that

Also wired up to Recovery search screen - this is good, we will search whether there are active recoveries for an account already, and also whether guardians are set up for an account. 

Depending on the outcome we then show different screens. 

If there already is an active recovery, we also need to remember that and show on settings screen, probably. 

### ✅ Checklist

- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Mainly just added the icon on settings screen, minimal changes to the next screen. 

### 🙈 Screenshots

<img width="459" alt="image" src="https://user-images.githubusercontent.com/65412/184657324-277b7dda-648c-411f-bb52-55c62a112cf3.png">

### 👯‍♀️ Paired with
