### PR TITLE
generating deep link data and packing it into a URI

### DIFF
--- a/lib/blocs/deeplink/mappers/deep_link_state_mapper.dart
+++ b/lib/blocs/deeplink/mappers/deep_link_state_mapper.dart
@@ -1,40 +1,21 @@
 import 'package:hashed/blocs/deeplink/model/deep_link_data.dart';
 import 'package:hashed/blocs/deeplink/model/guardian_recovery_request_data.dart';
-import 'package:hashed/blocs/deeplink/model/invite_link_data.dart';
 import 'package:hashed/blocs/deeplink/viewmodels/deeplink_bloc.dart';
-import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/domain-shared/result_to_state_mapper.dart';
-import 'package:hashed/utils/result_extension.dart';
-import 'package:hashed/utils/string_extension.dart';
 
 // Example guardian Link: https://joinseeds.com/?placeholder&guardian=esr://gmN0S9_Eeqy57zv_9xn9eU3hL_bxCbUs-jptJqsXY3-JtawgA0NBEFdzSW8aAwPDg1W-E3cxMjJAABOUdoMJCPBcMvRdvD7S1NU_2MIsL8itJC_YvSTTODk50M0jOKPcKSjFMsXN0M0xxNDNvDC10tDHLNsvMbjA1Nk8qdAXaAoA
 class DeepLinkStateMapper extends StateMapper {
   DeeplinkState mapResultToState(DeeplinkState currentState, DeepLinkData deepLinkData) {
     switch (deepLinkData.deepLinkPlaceHolder) {
       case DeepLinkPlaceHolder.guardian:
-        final newPublicKey = deepLinkData.data['new_public_key'];
-        final userAccount = deepLinkData.data['user_account'];
+        final lostAccount = deepLinkData.data['lostAccount'];
+        final rescuer = deepLinkData.data['rescuer'];
         return currentState.copyWith(
           showGuardianApproveOrDenyScreen: GuardianRecoveryRequestData(
-            guardianAccount: userAccount,
-            publicKey: newPublicKey,
+            lostAccount: lostAccount,
+            rescuer: rescuer,
           ),
         );
-      case DeepLinkPlaceHolder.invite:
-        if (accountService.currentAccount.address.isNullOrEmpty) {
-          // Handle invite link. Send user to memonic screen.
-          return currentState.copyWith(inviteLinkData: InviteLinkData(deepLinkData.data['Mnemonic']));
-        } else {
-          //  If user is logged in, Ignore invite link
-          return currentState;
-        }
-      case DeepLinkPlaceHolder.invoice:
-        final invite = deepLinkData.data['invoice'] as Result<dynamic>;
-        if (invite.isValue) {
-          return currentState.copyWith(signingRequest: invite.valueOrNull);
-        } else {
-          return currentState;
-        }
       case DeepLinkPlaceHolder.unknown:
         // Don't know how to handle this link. Return current state
         return currentState;

--- a/lib/blocs/deeplink/model/deep_link_data.dart
+++ b/lib/blocs/deeplink/model/deep_link_data.dart
@@ -5,4 +5,4 @@ class DeepLinkData {
   const DeepLinkData(this.data, this.deepLinkPlaceHolder);
 }
 
-enum DeepLinkPlaceHolder { guardian, invite, invoice, unknown }
+enum DeepLinkPlaceHolder { guardian, unknown }

--- a/lib/blocs/deeplink/model/guardian_recovery_request_data.dart
+++ b/lib/blocs/deeplink/model/guardian_recovery_request_data.dart
@@ -1,9 +1,9 @@
 class GuardianRecoveryRequestData {
-  final String guardianAccount;
-  final String publicKey;
+  final String lostAccount;
+  final String rescuer;
 
   GuardianRecoveryRequestData({
-    required this.guardianAccount,
-    required this.publicKey,
+    required this.lostAccount,
+    required this.rescuer,
   });
 }

--- a/lib/blocs/deeplink/usecase/get_initial_deep_link_use_case.dart
+++ b/lib/blocs/deeplink/usecase/get_initial_deep_link_use_case.dart
@@ -1,4 +1,3 @@
-import 'package:async/async.dart';
 import 'package:hashed/blocs/deeplink/model/deep_link_data.dart';
 import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/datasource/local/util/seeds_esr.dart';
@@ -22,11 +21,6 @@ class GetInitialDeepLinkUseCase {
         final action = request.actions.first;
         final data = Map<String, dynamic>.from(action.data! as Map<dynamic, dynamic>);
         return DeepLinkData(data, deepLinkPlaceHolder);
-      case DeepLinkPlaceHolder.invite:
-        return DeepLinkData({'Mnemonic': linkData}, deepLinkPlaceHolder);
-      case DeepLinkPlaceHolder.invoice:
-        final Result esrData = await getSigningRequestUseCase.run(linkData);
-        return DeepLinkData({'invoice': esrData}, deepLinkPlaceHolder);
       default:
         return DeepLinkData({}, deepLinkPlaceHolder);
     }

--- a/lib/datasource/local/firebase_dynamic_link_service.dart
+++ b/lib/datasource/local/firebase_dynamic_link_service.dart
@@ -5,7 +5,7 @@ import 'package:hashed/domain-shared/base_use_case.dart';
 
 class FirebaseDynamicLinkService {
   // guardianTargetLink
-  Future<Result<Uri>> createDynamicLink(String targetLink, Uri link) async {
+  Future<Result<Uri>> createDynamicLink(Uri link) async {
     try {
       final parameters = DynamicLinkParameters(
         uriPrefix: domainAppUriPrefix,

--- a/lib/datasource/local/firebase_dynamic_link_service.dart
+++ b/lib/datasource/local/firebase_dynamic_link_service.dart
@@ -4,11 +4,12 @@ import 'package:hashed/domain-shared/app_constants.dart';
 import 'package:hashed/domain-shared/base_use_case.dart';
 
 class FirebaseDynamicLinkService {
-  Future<Result<Uri>> createDynamicLink(String targetLink, String link) async {
+  // guardianTargetLink
+  Future<Result<Uri>> createDynamicLink(String targetLink, Uri link) async {
     try {
       final parameters = DynamicLinkParameters(
         uriPrefix: domainAppUriPrefix,
-        link: Uri.parse('$targetLink$link'),
+        link: link,
         androidParameters: AndroidParameters(packageName: androidPacakageName),
         iosParameters: IosParameters(bundleId: iosBundleId, appStoreId: iosAppStoreId),
       );

--- a/lib/datasource/remote/api/guardians_repository.dart
+++ b/lib/datasource/remote/api/guardians_repository.dart
@@ -41,9 +41,10 @@ class GuardiansRepository with HttpRepository {
   ///
   /// When 2 or 3 of the guardians call this function, the account can be recovered with claim
   ///
-  Future<Result> recoverAccount(String userAccount, String publicKey) async {
+  Future<Result> recoverAccount({required String lostAccount, required String rescuerAccount}) async {
     // This will need to be removed - works different on Polkadot / Subsrate
-    throw UnimplementedError();
+    return polkadotRepository.recoveryRepository.vouch(
+        address: accountService.currentAccount.address, lostAccount: lostAccount, recovererAccount: rescuerAccount);
   }
 
   Future<Result<dynamic>> getAccountRecovery(String lostAccountName) async {

--- a/lib/domain-shared/app_constants.dart
+++ b/lib/domain-shared/app_constants.dart
@@ -3,7 +3,7 @@ const String domainAppUriPrefix = 'https://hashedwallet.page.link';
 const String guardianTargetLink = 'https://app.hashed.io/vouch/?lostAccount=&rescuer=';
 const String androidPacakageName = 'io.hashed.wallet';
 const String iosBundleId = 'io.hashed.wallet';
-const String iosAppStoreId = '1507143650';
+const String iosAppStoreId = '1639248612';
 
 /// Actions
 const String transferAction = 'transfer';

--- a/lib/domain-shared/app_constants.dart
+++ b/lib/domain-shared/app_constants.dart
@@ -1,21 +1,9 @@
-/// Some URLs
-const String p2pAppUrl = 'https://ptm.hypha.earth/';
-const String urlBuySeeds = 'https://www.joinseeds.earth/buy-seeds?acc=';
-
 /// Firebase Dynamic Link Parameters
-const String domainAppUriPrefix = 'https://seedswallet.page.link';
-const String targetLink = 'https://joinseeds.com/?placeholder=&inviteMnemonic=';
-const String guardianTargetLink = 'https://joinseeds.com/?placeholder=&guardian=';
-const String invoiceTargetLink = 'https://joinseeds.com/?placeholder=&invoice=';
-const String androidPacakageName = 'com.joinseeds.seedswallet';
-const String iosBundleId = 'com.joinseeds.seedslight';
+const String domainAppUriPrefix = 'https://hashedwallet.page.link';
+const String guardianTargetLink = 'https://app.hashed.io/vouch/?lostAccount=&rescuer=';
+const String androidPacakageName = 'io.hashed.wallet';
+const String iosBundleId = 'io.hashed.wallet';
 const String iosAppStoreId = '1507143650';
 
 /// Actions
 const String transferAction = 'transfer';
-
-/// ESR invoice
-const String chainId = '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11';
-
-/// Unplanted minimum balance requirement
-const double minPlanted = 5.0;

--- a/lib/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart
@@ -1,10 +1,19 @@
 import 'package:async/async.dart';
+import 'package:hashed/blocs/deeplink/model/guardian_recovery_request_data.dart';
 import 'package:hashed/datasource/local/firebase_dynamic_link_service.dart';
+import 'package:hashed/domain-shared/app_constants.dart';
 
 class CreateFirebaseDynamicLinkUseCase {
   final FirebaseDynamicLinkService _firebaseDynamicLinkService = FirebaseDynamicLinkService();
 
-  Future<Result<Uri>> createDynamicLink(String targetLink, String link) async {
-    return _firebaseDynamicLinkService.createDynamicLink(targetLink, link);
+  Future<Result<Uri>> createDynamicLink(String targetLink, GuardianRecoveryRequestData data) async {
+    final uri = Uri.parse(guardianTargetLink).replace(queryParameters: {
+      'lostAccount': data.lostAccount,
+      'rescuer': data.rescuer,
+    });
+
+    print("recover link: $uri");
+
+    return _firebaseDynamicLinkService.createDynamicLink(targetLink, uri);
   }
 }

--- a/lib/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart
@@ -6,7 +6,7 @@ import 'package:hashed/domain-shared/app_constants.dart';
 class CreateFirebaseDynamicLinkUseCase {
   final FirebaseDynamicLinkService _firebaseDynamicLinkService = FirebaseDynamicLinkService();
 
-  Future<Result<Uri>> createDynamicLink(String targetLink, GuardianRecoveryRequestData data) async {
+  Future<Result<Uri>> createDynamicLink(GuardianRecoveryRequestData data) async {
     final uri = Uri.parse(guardianTargetLink).replace(queryParameters: {
       'lostAccount': data.lostAccount,
       'rescuer': data.rescuer,
@@ -14,6 +14,6 @@ class CreateFirebaseDynamicLinkUseCase {
 
     print("recover link: $uri");
 
-    return _firebaseDynamicLinkService.createDynamicLink(targetLink, uri);
+    return _firebaseDynamicLinkService.createDynamicLink(uri);
   }
 }

--- a/lib/screens/app/components/guardian_approve_or_deny_recovery_screen.dart
+++ b/lib/screens/app/components/guardian_approve_or_deny_recovery_screen.dart
@@ -45,7 +45,7 @@ class GuardianApproveOrDenyScreen extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 30),
               child: Text(
-                '${data.guardianAccount}'
+                '${data.lostAccount}'
                         ' has initiated their account recovery process through their Key Guardians. Accepting this request will help them to recover their account. Please make sure they are who they claim to be and are actually locked out of their account before accepting.'
                     .i18n,
                 textAlign: TextAlign.center,

--- a/lib/screens/app/interactor/usecases/approve_guardian_recovery_use_case.dart
+++ b/lib/screens/app/interactor/usecases/approve_guardian_recovery_use_case.dart
@@ -7,13 +7,14 @@ class ApproveGuardianRecoveryUseCase {
   final FirebaseDatabaseGuardiansRepository _databaseGuardiansRepository = FirebaseDatabaseGuardiansRepository();
 
   Future<Result> approveGuardianRecovery(String userAccount, String publicKey) async {
-    final result = await _guardiansRepository.recoverAccount(userAccount, publicKey);
+    throw UnimplementedError("not sure we need this");
+    // final result = await _guardiansRepository.recoverAccount(userAccount, publicKey);
 
-    // If recover call success, Init the firebase recovery flag.
-    if (result.isValue) {
-      await _databaseGuardiansRepository.setGuardianRecoveryStarted(userAccount);
-    }
+    // // If recover call success, Init the firebase recovery flag.
+    // if (result.isValue) {
+    //   await _databaseGuardiansRepository.setGuardianRecoveryStarted(userAccount);
+    // }
 
-    return result;
+    // return result;
   }
 }

--- a/lib/screens/app/interactor/viewmodels/app_bloc.dart
+++ b/lib/screens/app/interactor/viewmodels/app_bloc.dart
@@ -115,9 +115,15 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     // Update Deep Link Bloc State
     _deeplinkBloc.add(const OnGuardianRecoveryRequestSeen());
     emit(state.copyWith(pageState: PageState.loading));
-    final result = await ApproveGuardianRecoveryUseCase()
-        .approveGuardianRecovery(event.data.guardianAccount, event.data.publicKey);
-    emit(ApproveGuardianRecoveryStateMapper().mapResultToState(state, result));
+
+    /// this should simply take the data - lostAccount and rescuer - and vouch.
+    ///
+
+    throw UnimplementedError("implement this or remove.");
+
+    // final result = await ApproveGuardianRecoveryUseCase()
+    //     .approveGuardianRecovery(lostAccount: event.data.lostAccount, rescuer: event.data.rescuer);
+    // emit(ApproveGuardianRecoveryStateMapper().mapResultToState(state, result));
   }
 
   void _onApproveGuardianRecoveryDeepLink(OnApproveGuardianRecoveryDeepLink event, Emitter<AppState> emit) {

--- a/lib/screens/authentication/recover/recover_account_found/interactor/usecases/fetch_recover_guardian_initial_data.dart
+++ b/lib/screens/authentication/recover/recover_account_found/interactor/usecases/fetch_recover_guardian_initial_data.dart
@@ -1,4 +1,7 @@
+// ignore_for_file: prefer_final_locals, unused_local_variable
+
 import 'package:async/async.dart';
+import 'package:hashed/blocs/deeplink/model/guardian_recovery_request_data.dart';
 import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/datasource/local/models/account.dart';
 
@@ -31,14 +34,9 @@ class FetchRecoverGuardianInitialDataUseCase {
     }
   }
 
-  Future<Result<dynamic>> generateFirebaseDynamicLink(Result<dynamic> link) async {
-    if (link.isValue) {
-      final String linkValue = link.asValue!.value;
-      final guardianLink = await _createFirebaseDynamicLinkUseCase.createDynamicLink(guardianTargetLink, linkValue);
-      return guardianLink;
-    } else {
-      return link;
-    }
+  Future<Result<dynamic>> generateFirebaseDynamicLink(GuardianRecoveryRequestData data) async {
+    final guardianLink = await _createFirebaseDynamicLinkUseCase.createDynamicLink(guardianTargetLink, data);
+    return guardianLink;
   }
 
   /// USER already started a recovery. Fetch the values from storage
@@ -70,15 +68,18 @@ class FetchRecoverGuardianInitialDataUseCase {
 
     Result link = await _guardiansRepository.generateRecoveryRequest(accountName, publicKey!);
 
-    // Check
-    link = await generateFirebaseDynamicLink(link);
+    throw UnimplementedError("start recovery not implemented");
 
-    return RecoverGuardianInitialDTO(
-        link: link,
-        membersData: membersData,
-        userRecoversModel: accountRecovery,
-        accountGuardians: accountGuardians,
-        authData: authData);
+    /// TODO - remove this class or implement this
+    // Check
+    // link = await generateFirebaseDynamicLink(link);
+
+    // return RecoverGuardianInitialDTO(
+    //     link: link,
+    //     membersData: membersData,
+    //     userRecoversModel: accountRecovery,
+    //     accountGuardians: accountGuardians,
+    //     authData: authData);
   }
 }
 

--- a/lib/screens/authentication/recover/recover_account_found/interactor/usecases/fetch_recover_guardian_initial_data.dart
+++ b/lib/screens/authentication/recover/recover_account_found/interactor/usecases/fetch_recover_guardian_initial_data.dart
@@ -8,7 +8,6 @@ import 'package:hashed/datasource/local/models/account.dart';
 import 'package:hashed/datasource/local/models/auth_data_model.dart';
 import 'package:hashed/datasource/local/settings_storage.dart';
 import 'package:hashed/datasource/remote/api/guardians_repository.dart';
-import 'package:hashed/domain-shared/app_constants.dart';
 import 'package:hashed/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart';
 import 'package:hashed/domain-shared/shared_use_cases/generate_random_key_and_words_use_case.dart';
 
@@ -35,7 +34,7 @@ class FetchRecoverGuardianInitialDataUseCase {
   }
 
   Future<Result<dynamic>> generateFirebaseDynamicLink(GuardianRecoveryRequestData data) async {
-    final guardianLink = await _createFirebaseDynamicLinkUseCase.createDynamicLink(guardianTargetLink, data);
+    final guardianLink = await _createFirebaseDynamicLinkUseCase.createDynamicLink(data);
     return guardianLink;
   }
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Generate deep link data

I changed some of the guardian data model classes

Also changed a use case

Did not change code upstream since I think we don't need a lot of it - we don't need to keep track of the recovery process, it's all on chain. I think the only thing we need to keep track of on the user's end is which account addresses they have initiated recoveries for. 

Once the recovery is complete we will be able to access the "proxy" table on the recovery pallet to see which active recoveries an account has (next PR)

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

This creates a link 
```
https://app.hashed.io/vouch/?lostAccount=&rescuer=
```
Which is then wrapped into a deeplink. 

It does not parse the incoming link. 

I think some of the old code should be removed - really all we need is take two strings, lostAccount and rescuer, and create a deep link with that for the user to share with their guardians. 

No need to have a lot of lookups and logic as we needed on the seeds light wallet. 

### 🙈 Screenshots

### 👯‍♀️ Paired with

