### PR TITLE
Feature/recovery overview screen

### DIFF
--- a/lib/datasource/local/flutter_js/substrate_service.dart
+++ b/lib/datasource/local/flutter_js/substrate_service.dart
@@ -42,6 +42,7 @@ class SubstrateService {
   }
 
   Future<int?> connect() async {
+    print("Substrate Service: CONNECT");
     if (!_initialized) {
       throw "you have to initialize the service before connecting";
     }
@@ -86,13 +87,16 @@ class SubstrateService {
   /// Keep alive timer accurately reports when the connection is down
   /// It does not take actions other than calling the connectionStateHandler
   void startKeepAliveTimer() {
-    _keepAliveTimer = Timer(const Duration(seconds: 6), () async {
+    _keepAliveTimer = Timer.periodic(const Duration(seconds: 6), (timer) async {
       final aliveCheckSuccess = await _runAliveCheck();
+      print("alive check $aliveCheckSuccess");
+
       if (aliveCheckSuccess) {
         _lastCheck = DateTime.now();
       } else {
         /// Alive check failed - we ignore a certain number of failed alive checks
         if (_lastCheck != null) {
+          print("dead time: ${DateTime.now().difference(_lastCheck!).inSeconds}");
           if (DateTime.now().difference(_lastCheck!).inSeconds > _aliveSeconds) {
             print("Network is disconnected");
             _keepAliveTimer?.cancel();

--- a/lib/datasource/local/settings_storage.dart
+++ b/lib/datasource/local/settings_storage.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/datasource/local/models/auth_data_model.dart';
+import 'package:hashed/datasource/remote/model/active_recovery_model.dart';
 import 'package:hashed/datasource/remote/model/token_model.dart';
 import 'package:hashed/domain-shared/ui_constants.dart';
 import 'package:intl/intl.dart';
@@ -25,6 +26,8 @@ const String _kDateSinceRateAppPrompted = 'date_since_rate_app_prompted';
 const String _kAccounts = "accounts";
 const String _kCurrentAccount = "current_account";
 const String _kPrivateKeys = "private_keys";
+
+const String _kActiveRecoveryAccount = "active_recovery_account";
 
 class _SettingsStorage implements AbstractStorage {
   late SharedPreferences _preferences;
@@ -123,6 +126,16 @@ class _SettingsStorage implements AbstractStorage {
   set dateSinceRateAppPrompted(int? value) {
     if (value != null) {
       _preferences.setInt(_kDateSinceRateAppPrompted, value);
+    }
+  }
+
+  String? get activeRecoveryAccount => _preferences.getString(_kActiveRecoveryAccount);
+
+  set activeRecoveryAccount(String? value) {
+    if (value != null) {
+      _preferences.setString(_kActiveRecoveryAccount, value);
+    } else {
+      _preferences.remove(_kActiveRecoveryAccount);
     }
   }
 

--- a/lib/datasource/remote/model/active_recovery_model.dart
+++ b/lib/datasource/remote/model/active_recovery_model.dart
@@ -1,8 +1,6 @@
 /// Represents an active recovery
 ///
 class ActiveRecoveryModel {
-  final String key;
-
   /// the account it is trying to recover
   final String lostAccount;
 
@@ -18,16 +16,15 @@ class ActiveRecoveryModel {
   /// the list of friends / guardians who have already signed - can be empty
   final List<String> friends;
 
-  ActiveRecoveryModel(
-      {required this.key,
-      required this.lostAccount,
-      required this.rescuer,
-      required this.created,
-      required this.deposit,
-      required this.friends});
+  ActiveRecoveryModel({
+    required this.lostAccount,
+    required this.rescuer,
+    required this.created,
+    required this.deposit,
+    required this.friends,
+  });
 
   factory ActiveRecoveryModel.fromJson(Map<String, dynamic> json) {
-    final key = json["key"];
     final lostAccount = json["lostAccount"];
     final rescuer = json["rescuer"];
 
@@ -37,7 +34,6 @@ class ActiveRecoveryModel {
     final friends = List<String>.from(data["friends"]);
 
     return ActiveRecoveryModel(
-      key: key,
       lostAccount: lostAccount,
       rescuer: rescuer,
       created: created,
@@ -46,9 +42,39 @@ class ActiveRecoveryModel {
     );
   }
 
+  /// Use this factory model for results for a specific rescuer / lostAccount
+  /// combination.
+  factory ActiveRecoveryModel.fromJsonSingle({
+    required String rescuer,
+    required String lostAccount,
+    required Map<String, dynamic> json,
+  }) {
+    final int created = json['created'];
+    final int deposit = json['deposit'];
+    final friends = List<String>.from(json["friends"]);
+
+    return ActiveRecoveryModel(
+      lostAccount: lostAccount,
+      rescuer: rescuer,
+      created: created,
+      deposit: deposit,
+      friends: friends,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      "lostAccount": lostAccount,
+      "rescuer": rescuer,
+      "data": {
+        "created": created,
+        "deposit": deposit,
+        "friends": friends,
+      }
+    };
+  }
+
   static final mock = ActiveRecoveryModel(
-    key:
-        "0xa2ce73642c549ae79c14f0a671cf45f9dff9094d7baf1e2d9b2e3a4253b096f86c7090fd2359d471e63883edb4a6a0cdebfac75f34f14f34d3cbffc154ae4c7f28ea266addddf8501493c613e8bdafc0b25475e47c779546c9b6ab58e0bdbdc2245503284a8dfe4c324e6dc285c88a1d",
     lostAccount: "5HGZfBpqUUqGY7uRCYA6aRwnRHJVhrikn8to31GcfNcifkym",
     rescuer: "5G6XUFXZsdUYdB84eEjvPP33tFF1DjbSg7MPsNAx3mVDnxaW",
     created: 1035220,

--- a/lib/datasource/remote/polkadot_api/recovery_repository.dart
+++ b/lib/datasource/remote/polkadot_api/recovery_repository.dart
@@ -57,23 +57,6 @@ class RecoveryRepository extends ExtrinsicsRepository {
     }
   }
 
-  Future<Result<dynamic>> getProxies(String address) async {
-    print("get proxies for $address");
-
-    try {
-      final code = 'api.query.recovery.proxy("$address")';
-      final res = await evalJavascript(code: code);
-      print("getProxies res: $res");
-
-      // TODO(n13): parse list of addresses
-
-      return Result.value(res);
-    } catch (err) {
-      print('getProxies error: $err');
-      return Result.error(err);
-    }
-  }
-
   /// Removes user's guardians. User must Start from scratch.
   /// Recovers fees.
   Future<Result> removeRecovery({required String address}) async {
@@ -305,6 +288,30 @@ class RecoveryRepository extends ExtrinsicsRepository {
     } catch (err, s) {
       print('cancelRecovered error $err');
       print(s);
+      return Result.error(err);
+    }
+  }
+
+  /// return recoveries that are currently in process for the address in question
+  /// Params: Address to be recovered
+  Future<Result<List<String>>> getProxies(String address, {bool mock = false}) async {
+    print("get proxy for $address");
+
+    if (mock) {
+      return Future.delayed(const Duration(milliseconds: 500), () => Result.value(["5x01testdata", "5x02testdata"]));
+    }
+
+    try {
+      final code = 'api.query.recovery.proxy.entries("$address")';
+
+      final res = await evalJavascript(code: code);
+      final list = List<String>.from(res);
+      // final proxies = list.map((e) => ActiveRecoveryModel.fromJson(e)).toList();
+
+      return Result.value(list);
+    } catch (err, stacktrace) {
+      print('getProxies error: $err');
+      print(stacktrace);
       return Result.error(err);
     }
   }

--- a/lib/datasource/remote/polkadot_api/recovery_repository.dart
+++ b/lib/datasource/remote/polkadot_api/recovery_repository.dart
@@ -306,7 +306,6 @@ class RecoveryRepository extends ExtrinsicsRepository {
 
       final res = await evalJavascript(code: code);
       final list = List<String>.from(res);
-      // final proxies = list.map((e) => ActiveRecoveryModel.fromJson(e)).toList();
 
       return Result.value(list);
     } catch (err, stacktrace) {

--- a/lib/datasource/remote/polkadot_api/recovery_repository.dart
+++ b/lib/datasource/remote/polkadot_api/recovery_repository.dart
@@ -130,12 +130,38 @@ class RecoveryRepository extends ExtrinsicsRepository {
           data: v.toJSON() 
         } 
       })''';
+
       final res = await evalJavascript(code: code, transformer: transformer);
 
       final list = List.from(res);
       final recoveries = list.map((e) => ActiveRecoveryModel.fromJson(e)).toList();
 
       return Result.value(recoveries);
+    } catch (err, stacktrace) {
+      print('getActiveRecoveries error: $err');
+      print(stacktrace);
+      return Result.error(err);
+    }
+  }
+
+  Future<Result<ActiveRecoveryModel?>> getActiveRecoveriesForLostaccount(
+    String rescuer,
+    String lostAccount, {
+    bool mock = false,
+  }) async {
+    print("get active recovery for $rescuer and $lostAccount");
+
+    if (mock) {
+      return Future.delayed(const Duration(milliseconds: 500), () => Result.value(ActiveRecoveryModel.mock));
+    }
+
+    try {
+      final code = 'api.query.recovery.activeRecoveries("$lostAccount", "$rescuer")';
+      final res = await evalJavascript(code: code);
+
+      final recovery = ActiveRecoveryModel.fromJsonSingle(rescuer: rescuer, lostAccount: lostAccount, json: res);
+
+      return Result.value(recovery);
     } catch (err, stacktrace) {
       print('getActiveRecoveries error: $err');
       print(stacktrace);

--- a/lib/design/app_color_schemes.dart
+++ b/lib/design/app_color_schemes.dart
@@ -25,6 +25,11 @@ class AppColorSchemes {
     /// Used for card backgrounds that float above the background
     surface: Color(0xFF293E84),
     onSurface: Color(0xFFFFFFFF),
+
+    /// Alternative background - currently the same as primary
+    /// Used for card backgrounds that float above the background
+    tertiaryContainer: Color(0xFF5D5E67),
+    onTertiaryContainer: Color(0xFFFFFFFF),
   );
 
   // TODO(n13): not in use.

--- a/lib/navigation/navigation_service.dart
+++ b/lib/navigation/navigation_service.dart
@@ -8,6 +8,8 @@ import 'package:hashed/screens/authentication/create_nickname/create_nickname_sc
 import 'package:hashed/screens/authentication/import_key/import_key_screen.dart';
 import 'package:hashed/screens/authentication/login_screen.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_details/recover_account_details_page.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_search/recover_account_screen.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_success/recover_account_success_page.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_timer/recover_account_timer_page.dart';
@@ -40,6 +42,7 @@ class Routes {
   static const signup = 'signup';
   static const recoverAccountSearch = 'recoverAccountSearch';
   static const recoveryPhrase = 'recoveryPhrase';
+  static const recoverAccountOverview = 'recoverAccountOverview';
   static const recoverAccountDetails = 'recoverAccountDetails';
   static const recoverAccountSuccess = 'recoverAccountSuccess';
   static const recoverAccountTimer = 'recoverAccountTimer';
@@ -76,6 +79,7 @@ class NavigationService {
     Routes.verification: (_) => const VerificationScreen(),
     Routes.verificationUnpoppable: (_) => const VerificationScreen.unpoppable(),
     Routes.recoverAccountSearch: (_) => const RecoverAccountScreen(),
+    Routes.recoverAccountOverview: (_) => const RecoverAccountOverviewPage(),
     Routes.recoverAccountDetails: (_) => const RecoverAccountDetailsPage(),
     Routes.recoverAccountSuccess: (_) => const RecoverAccountSuccessPage(),
     Routes.recoverAccountTimer: (_) => const RecoverAccountTimerPage(),

--- a/lib/screens/authentication/recover/recover_account_details/interactor/usecase/fetch_recover_account_details_data.dart
+++ b/lib/screens/authentication/recover/recover_account_details/interactor/usecase/fetch_recover_account_details_data.dart
@@ -5,7 +5,7 @@ import 'package:hashed/datasource/remote/model/guardians_config_model.dart';
 import 'package:hashed/domain-shared/base_use_case.dart';
 import 'package:hashed/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart';
 
-class FetchRecoverAccountDetailsData {
+class FetchRecoverAccountDetailsUsecase {
   final GuardiansRepository _guardiansRepository = GuardiansRepository();
 
   Future<Result<RecoveryResultData>> run(String accountName) async {

--- a/lib/screens/authentication/recover/recover_account_details/interactor/usecase/fetch_recover_account_details_data.dart
+++ b/lib/screens/authentication/recover/recover_account_details/interactor/usecase/fetch_recover_account_details_data.dart
@@ -9,11 +9,6 @@ class FetchRecoverAccountDetailsData {
   final GuardiansRepository _guardiansRepository = GuardiansRepository();
 
   Future<Result<RecoveryResultData>> run(String accountName) async {
-    // This object is questionable, it seems to combine different chain calls
-    // the link is generated in app, from rescuer and lostAccount
-    // the lookup for lostAccount is getting the active recoveries and the recovery config.
-    // Therefore I don't think we should have this artificual resultDAta object?
-
     final configResult = await _guardiansRepository.getAccountGuardians(accountName);
     final activeResult = await _guardiansRepository.getAccountRecovery(accountName);
 

--- a/lib/screens/authentication/recover/recover_account_details/interactor/viewmodels/recover_account_details_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_details/interactor/viewmodels/recover_account_details_bloc.dart
@@ -19,7 +19,7 @@ class RecoverAccountDetailsBloc extends Bloc<RecoverAccountDetailsEvent, Recover
 
   Future<void> _fetchInitialData(FetchInitialData event, Emitter<RecoverAccountDetailsState> emit) async {
     emit(state.copyWith(pageState: PageState.loading));
-    final Result<RecoveryResultData> result = await FetchRecoverAccountDetailsData().run(state.userAccount);
+    final Result<RecoveryResultData> result = await FetchRecoverAccountDetailsUsecase().run(state.userAccount);
 
     if (result.isValue) {
       final data = result.asValue!.value;

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
@@ -54,7 +54,7 @@ class RecoverAccountOverviewView extends StatelessWidget {
                           BlocProvider.of<RecoverAccountOverviewBloc>(context)
                               .add(OnRecoveryInProcessTapped(state.activeRecovery!.lostAccount));
                         }),
-                  const SizedBox(height: 16),
+                  if (state.activeRecovery != null) const SizedBox(height: 16),
                   if (state.recoveredAccounts.isNotEmpty)
                     Text(
                       "Recovered Accounts",

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hashed/components/full_page_error_indicator.dart';
+import 'package:hashed/components/full_page_loading_indicator.dart';
+import 'package:hashed/domain-shared/page_state.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart';
+import 'package:hashed/screens/settings/components/settings_card.dart';
+import 'package:hashed/utils/ThemeBuildContext.dart';
+import 'package:hashed/utils/short_string.dart';
+
+class RecoverAccountOverView extends StatelessWidget {
+  const RecoverAccountOverView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<RecoverAccountOverviewBloc, RecoverAccountOverviewState>(
+      builder: (context, state) {
+        switch (state.pageState) {
+          case PageState.loading:
+            return const FullPageLoadingIndicator();
+          case PageState.failure:
+            return FullPageErrorIndicator(
+              errorMessage: 'Oops, Something went wrong.',
+              buttonTitle: 'Refresh',
+              buttonOnPressed: () => BlocProvider.of<RecoverAccountOverviewBloc>(context).add(const OnRefreshTapped()),
+            );
+          case PageState.initial:
+          case PageState.success:
+            if (state.recoveredAccounts.isNotEmpty) {}
+            return Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  SettingsCard(
+                    icon: const Icon(Icons.replay_circle_filled_outlined),
+                    title: "Recover an Account",
+                    description: "Recover an account with the help of the guardians set for that account.",
+                    onTap: () async {
+                      BlocProvider.of<RecoverAccountOverviewBloc>(context).add(const OnRecoverAccountTapped());
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  if (state.activeRecovery != null)
+                    SettingsCard(
+                        backgroundColor: context.colorScheme.tertiaryContainer,
+                        textColor: context.colorScheme.onTertiaryContainer,
+                        icon: const Icon(Icons.keyboard_command_key),
+                        title: "Recovery in Process",
+                        description: "Recovering    ${state.activeRecovery!.lostAccount.shorter}",
+                        onTap: () async {
+                          BlocProvider.of<RecoverAccountOverviewBloc>(context)
+                              .add(OnRecoveryInProcessTapped(state.activeRecovery!.lostAccount));
+                        }),
+                  const SizedBox(height: 16),
+                  if (state.recoveredAccounts.isNotEmpty)
+                    Text(
+                      "Recovered Accounts",
+                      style: context.textTheme.headline6,
+                    ),
+                  const SizedBox(height: 16),
+                  ...state.recoveredAccounts.map((e) => ListTile(
+                        title: Text(e.shorter),
+                        trailing: Icon(
+                          Icons.check_circle,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      )),
+                ],
+              ),
+            );
+        }
+      },
+    );
+  }
+}

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
@@ -4,12 +4,13 @@ import 'package:hashed/components/full_page_error_indicator.dart';
 import 'package:hashed/components/full_page_loading_indicator.dart';
 import 'package:hashed/domain-shared/page_state.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart';
+import 'package:hashed/screens/settings/components/account_card.dart';
 import 'package:hashed/screens/settings/components/settings_card.dart';
 import 'package:hashed/utils/ThemeBuildContext.dart';
 import 'package:hashed/utils/short_string.dart';
 
-class RecoverAccountOverView extends StatelessWidget {
-  const RecoverAccountOverView({super.key});
+class RecoverAccountOverviewView extends StatelessWidget {
+  const RecoverAccountOverviewView({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +27,9 @@ class RecoverAccountOverView extends StatelessWidget {
             );
           case PageState.initial:
           case PageState.success:
-            if (state.recoveredAccounts.isNotEmpty) {}
+            if (state.recoveredAccounts.isNotEmpty) {
+              print("rec acct ${state.recoveredAccounts}");
+            }
             return Padding(
               padding: const EdgeInsets.all(16),
               child: Column(
@@ -58,13 +61,11 @@ class RecoverAccountOverView extends StatelessWidget {
                       style: context.textTheme.headline6,
                     ),
                   const SizedBox(height: 16),
-                  ...state.recoveredAccounts.map((e) => ListTile(
-                        title: Text(e.shorter),
-                        trailing: Icon(
-                          Icons.check_circle,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      )),
+                  ...state.recoveredAccounts.map((e) => AccountCard(
+                      address: e,
+                      icon: const Icon(
+                        Icons.bookmark,
+                      ))),
                 ],
               ),
             );

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart
@@ -9,8 +9,8 @@ import 'package:hashed/domain-shared/shared_use_cases/cerate_firebase_dynamic_li
 class FetchRecoverAccountOverviewData {
   final GuardiansRepository _guardiansRepository = GuardiansRepository();
 
-  Future<Result<RecoveryOverviewData>> run(String accountName, {String? lostAccount, bool mock = false}) async {
-    print("fetch overvew with $accountName and optional lost account: $lostAccount");
+  Future<Result<RecoveryOverviewData>> run(String accountAddress, {String? lostAccount, bool mock = false}) async {
+    print("fetch overvew with $accountAddress and optional lost account: $lostAccount");
 
     if (mock) {
       print("mock data");
@@ -21,16 +21,23 @@ class FetchRecoverAccountOverviewData {
 
     if (lostAccount != null) {
       activeResult =
-          await polkadotRepository.recoveryRepository.getActiveRecoveriesForLostaccount(accountName, lostAccount);
+          await polkadotRepository.recoveryRepository.getActiveRecoveriesForLostaccount(accountAddress, lostAccount);
       if (activeResult.isError) {
-        print("Error retrieving active recoveries for $accountName");
+        print("Error retrieving active recoveries for $accountAddress");
         return Result.error(activeResult.asError!.error);
       }
+    }
+
+    final proxies = await polkadotRepository.recoveryRepository.getProxies(accountAddress);
+    if (proxies.isError) {
+      print("Error retrieving proxies for $accountAddress");
+      return Result.error(proxies.asError!.error);
     }
 
     return Result.value(RecoveryOverviewData(
       activeRecoveryLostAccount: settingsStorage.activeRecoveryAccount,
       activeRecovery: activeResult?.asValue!.value,
+      proxyAccounts: proxies.asValue!.value,
     ));
   }
 }
@@ -49,5 +56,6 @@ class RecoveryOverviewData {
   static RecoveryOverviewData mock = RecoveryOverviewData(
     activeRecoveryLostAccount: ActiveRecoveryModel.mock.lostAccount,
     activeRecovery: ActiveRecoveryModel.mock,
+    proxyAccounts: ["5j_mock01", "5j_mock02"],
   );
 }

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart
@@ -1,0 +1,53 @@
+import 'package:hashed/blocs/deeplink/model/guardian_recovery_request_data.dart';
+import 'package:hashed/datasource/local/settings_storage.dart';
+import 'package:hashed/datasource/remote/api/guardians_repository.dart';
+import 'package:hashed/datasource/remote/model/active_recovery_model.dart';
+import 'package:hashed/datasource/remote/polkadot_api/polkadot_repository.dart';
+import 'package:hashed/domain-shared/base_use_case.dart';
+import 'package:hashed/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart';
+
+class FetchRecoverAccountOverviewData {
+  final GuardiansRepository _guardiansRepository = GuardiansRepository();
+
+  Future<Result<RecoveryOverviewData>> run(String accountName, {String? lostAccount, bool mock = false}) async {
+    print("fetch overvew with $accountName and optional lost account: $lostAccount");
+
+    if (mock) {
+      print("mock data");
+      return Result.value(RecoveryOverviewData.mock);
+    }
+
+    Result<ActiveRecoveryModel?>? activeResult;
+
+    if (lostAccount != null) {
+      activeResult =
+          await polkadotRepository.recoveryRepository.getActiveRecoveriesForLostaccount(accountName, lostAccount);
+      if (activeResult.isError) {
+        print("Error retrieving active recoveries for $accountName");
+        return Result.error(activeResult.asError!.error);
+      }
+    }
+
+    return Result.value(RecoveryOverviewData(
+      activeRecoveryLostAccount: settingsStorage.activeRecoveryAccount,
+      activeRecovery: activeResult?.asValue!.value,
+    ));
+  }
+}
+
+class RecoveryOverviewData {
+  final String? activeRecoveryLostAccount;
+  final ActiveRecoveryModel? activeRecovery;
+  final List<String> proxyAccounts;
+
+  RecoveryOverviewData({
+    required this.activeRecoveryLostAccount,
+    this.activeRecovery,
+    this.proxyAccounts = const [],
+  });
+
+  static RecoveryOverviewData mock = RecoveryOverviewData(
+    activeRecoveryLostAccount: ActiveRecoveryModel.mock.lostAccount,
+    activeRecovery: ActiveRecoveryModel.mock,
+  );
+}

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart
@@ -1,14 +1,9 @@
-import 'package:hashed/blocs/deeplink/model/guardian_recovery_request_data.dart';
 import 'package:hashed/datasource/local/settings_storage.dart';
-import 'package:hashed/datasource/remote/api/guardians_repository.dart';
 import 'package:hashed/datasource/remote/model/active_recovery_model.dart';
 import 'package:hashed/datasource/remote/polkadot_api/polkadot_repository.dart';
 import 'package:hashed/domain-shared/base_use_case.dart';
-import 'package:hashed/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart';
 
-class FetchRecoverAccountOverviewData {
-  final GuardiansRepository _guardiansRepository = GuardiansRepository();
-
+class FetchRecoverAccountOverviewUsecase {
   Future<Result<RecoveryOverviewData>> run(String accountAddress, {String? lostAccount, bool mock = false}) async {
     print("fetch overvew with $accountAddress and optional lost account: $lostAccount");
 

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:hashed/datasource/local/account_service.dart';
+import 'package:hashed/datasource/local/settings_storage.dart';
+import 'package:hashed/datasource/remote/model/active_recovery_model.dart';
+import 'package:hashed/domain-shared/page_command.dart';
+import 'package:hashed/domain-shared/page_state.dart';
+import 'package:hashed/navigation/navigation_service.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart';
+import 'package:hashed/utils/result_extension.dart';
+
+part 'recover_account_overview_event.dart';
+part 'recover_account_overview_state.dart';
+
+class RecoverAccountOverviewBloc extends Bloc<RecoverAccountOverviewEvent, RecoverAccountOverviewState> {
+  RecoverAccountOverviewBloc() : super(RecoverAccountOverviewState.initial()) {
+    on<FetchInitialData>(_fetchInitialData);
+    on<OnRefreshTapped>(_onRefreshTapped);
+    on<OnRecoverAccountTapped>(_onRecoverAccountTapped);
+    on<OnRecoveryInProcessTapped>(_onRecoveryInProcessTapped);
+  }
+
+  Future<void> _fetchInitialData(FetchInitialData event, Emitter<RecoverAccountOverviewState> emit) async {
+    emit(state.copyWith(pageState: PageState.loading));
+    final activeRecoveryAccount = settingsStorage.activeRecoveryAccount;
+    final Result<RecoveryOverviewData> result = await FetchRecoverAccountOverviewData().run(
+      accountService.currentAccount.address,
+      lostAccount: activeRecoveryAccount,
+      mock: true,
+    );
+
+    if (result.isValue) {
+      emit(state.copyWith(
+        pageState: PageState.success,
+        activeRecovery: result.asValue!.value.activeRecovery,
+      ));
+    } else {
+      print("Error ${result.asError!.error}");
+      emit(state.copyWith(pageState: PageState.failure));
+    }
+  }
+
+  FutureOr<void> _onRefreshTapped(OnRefreshTapped event, Emitter<RecoverAccountOverviewState> emit) {
+    add(const FetchInitialData());
+  }
+
+  Future<void> _onRecoverAccountTapped(OnRecoverAccountTapped event, Emitter<RecoverAccountOverviewState> emit) async {
+    emit(state.copyWith(pageCommand: NavigateToRoute(Routes.recoverAccountSearch)));
+  }
+
+  Future<void> _onRecoveryInProcessTapped(
+      OnRecoveryInProcessTapped event, Emitter<RecoverAccountOverviewState> emit) async {
+    emit(
+      state.copyWith(
+        pageCommand: NavigateToRouteWithArguments(route: Routes.recoverAccountDetails, arguments: event.lostAccount),
+      ),
+    );
+  }
+}

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
@@ -25,7 +25,7 @@ class RecoverAccountOverviewBloc extends Bloc<RecoverAccountOverviewEvent, Recov
   Future<void> _fetchInitialData(FetchInitialData event, Emitter<RecoverAccountOverviewState> emit) async {
     emit(state.copyWith(pageState: PageState.loading));
     final activeRecoveryAccount = settingsStorage.activeRecoveryAccount;
-    final Result<RecoveryOverviewData> result = await FetchRecoverAccountOverviewData().run(
+    final Result<RecoveryOverviewData> result = await FetchRecoverAccountOverviewUsecase().run(
       accountService.currentAccount.address,
       lostAccount: activeRecoveryAccount,
       mock: true,

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
@@ -35,6 +35,7 @@ class RecoverAccountOverviewBloc extends Bloc<RecoverAccountOverviewEvent, Recov
       emit(state.copyWith(
         pageState: PageState.success,
         activeRecovery: result.asValue!.value.activeRecovery,
+        recoveredAccounts: result.asValue!.value.proxyAccounts,
       ));
     } else {
       print("Error ${result.asError!.error}");

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_event.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_event.dart
@@ -1,0 +1,37 @@
+part of 'recover_account_overview_bloc.dart';
+
+abstract class RecoverAccountOverviewEvent extends Equatable {
+  const RecoverAccountOverviewEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class FetchInitialData extends RecoverAccountOverviewEvent {
+  const FetchInitialData();
+
+  @override
+  String toString() => 'FetchInitialData';
+}
+
+class OnRefreshTapped extends RecoverAccountOverviewEvent {
+  const OnRefreshTapped();
+
+  @override
+  String toString() => 'OnRefreshTapped';
+}
+
+class OnRecoverAccountTapped extends RecoverAccountOverviewEvent {
+  const OnRecoverAccountTapped();
+
+  @override
+  String toString() => 'OnRecoverAccountTapped';
+}
+
+class OnRecoveryInProcessTapped extends RecoverAccountOverviewEvent {
+  final String lostAccount;
+  const OnRecoveryInProcessTapped(this.lostAccount);
+
+  @override
+  String toString() => 'OnRecoveryInProcessTapped';
+}

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_page_command.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_page_command.dart
@@ -1,0 +1,3 @@
+import 'package:hashed/domain-shared/page_command.dart';
+
+class OnXXX extends PageCommand {}

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_state.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_state.dart
@@ -1,0 +1,43 @@
+part of 'recover_account_overview_bloc.dart';
+
+class RecoverAccountOverviewState extends Equatable {
+  final PageState pageState;
+  final PageCommand? pageCommand;
+  final ActiveRecoveryModel? activeRecovery;
+  final List<String> recoveredAccounts;
+
+  const RecoverAccountOverviewState({
+    required this.pageState,
+    this.pageCommand,
+    this.activeRecovery,
+    this.recoveredAccounts = const [],
+  });
+
+  @override
+  List<Object?> get props => [
+        pageState,
+        pageCommand,
+        activeRecovery,
+        recoveredAccounts,
+      ];
+
+  RecoverAccountOverviewState copyWith({
+    PageState? pageState,
+    PageCommand? pageCommand,
+    ActiveRecoveryModel? activeRecovery,
+    List<String>? recoveredAccounts,
+  }) {
+    return RecoverAccountOverviewState(
+      pageState: pageState ?? this.pageState,
+      pageCommand: pageCommand,
+      activeRecovery: activeRecovery ?? this.activeRecovery,
+      recoveredAccounts: recoveredAccounts ?? this.recoveredAccounts,
+    );
+  }
+
+  factory RecoverAccountOverviewState.initial() {
+    return const RecoverAccountOverviewState(
+      pageState: PageState.initial,
+    );
+  }
+}

--- a/lib/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart
@@ -29,7 +29,7 @@ class RecoverAccountOverviewPage extends StatelessWidget {
             builder: (BuildContext context, RecoverAccountOverviewState state) {
           return Scaffold(
               appBar: AppBar(
-                title: const Padding(padding: EdgeInsets.only(left: 16), child: Text("Recover Account")),
+                title: const Padding(padding: EdgeInsets.only(left: 16), child: Text("Recovery")),
                 automaticallyImplyLeading: false,
                 leading: Padding(
                   padding: const EdgeInsets.all(8.0),
@@ -49,7 +49,7 @@ class RecoverAccountOverviewPage extends StatelessWidget {
                   )
                 ],
               ),
-              body: const RecoverAccountOverView());
+              body: const RecoverAccountOverviewView());
         }),
       ),
     );

--- a/lib/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart
@@ -10,8 +10,6 @@ class RecoverAccountOverviewPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // ignore: cast_nullable_to_non_nullable
-    final String userAccount = ModalRoute.of(context)!.settings.arguments as String;
     return BlocProvider(
       create: (context) => RecoverAccountOverviewBloc()..add(const FetchInitialData()),
       child: BlocListener<RecoverAccountOverviewBloc, RecoverAccountOverviewState>(

--- a/lib/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hashed/domain-shared/page_command.dart';
+import 'package:hashed/navigation/navigation_service.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart';
+
+class RecoverAccountOverviewPage extends StatelessWidget {
+  const RecoverAccountOverviewPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // ignore: cast_nullable_to_non_nullable
+    final String userAccount = ModalRoute.of(context)!.settings.arguments as String;
+    return BlocProvider(
+      create: (context) => RecoverAccountOverviewBloc()..add(const FetchInitialData()),
+      child: BlocListener<RecoverAccountOverviewBloc, RecoverAccountOverviewState>(
+        listenWhen: (_, current) => current.pageCommand != null,
+        listener: (context, state) {
+          final pageCommand = state.pageCommand;
+          if (pageCommand is NavigateToRouteWithArguments) {
+            NavigationService.of(context).navigateTo(pageCommand.route, pageCommand.arguments);
+          }
+          if (pageCommand is NavigateToRoute) {
+            NavigationService.of(context).navigateTo(pageCommand.route);
+          }
+        },
+        child: BlocBuilder<RecoverAccountOverviewBloc, RecoverAccountOverviewState>(
+            builder: (BuildContext context, RecoverAccountOverviewState state) {
+          return Scaffold(
+              appBar: AppBar(
+                title: const Padding(padding: EdgeInsets.only(left: 16), child: Text("Recover Account")),
+                automaticallyImplyLeading: false,
+                leading: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ),
+                actions: [
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: IconButton(
+                      icon: const Icon(Icons.refresh),
+                      onPressed: () =>
+                          BlocProvider.of<RecoverAccountOverviewBloc>(context).add(const OnRefreshTapped()),
+                    ),
+                  )
+                ],
+              ),
+              body: const RecoverAccountOverView());
+        }),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/components/account_card.dart
+++ b/lib/screens/settings/components/account_card.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:hashed/domain-shared/ui_constants.dart';
+import 'package:hashed/utils/ThemeBuildContext.dart';
+import 'package:hashed/utils/short_string.dart';
+
+class AccountCard extends StatelessWidget {
+  final String address;
+  final String? accountName;
+  final Widget icon;
+
+  final GestureTapCallback? onTap;
+
+  final Color? backgroundColor;
+  final Color? textColor;
+
+  const AccountCard({
+    super.key,
+    required this.address,
+    required this.icon,
+    this.accountName,
+    this.onTap,
+    this.backgroundColor,
+    this.textColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        child: Ink(
+          decoration: BoxDecoration(
+            color: backgroundColor ?? context.colorScheme.surface,
+            borderRadius: BorderRadius.circular(defaultCardBorderRadius),
+          ),
+          child: Row(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    icon,
+                  ],
+                ),
+              ),
+              Expanded(
+                flex: 8,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 16.0, left: 16.0, top: 16, bottom: 16),
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          Flexible(
+                            child: Text(
+                              address.shorter,
+                              style: context.textTheme.bodyMedium!.copyWith(
+                                color: textColor ?? context.colorScheme.onSurface,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                        ],
+                      ),
+                      Row(
+                        children: [
+                          Flexible(
+                              child: Text(
+                            accountName ?? "",
+                            style: context.textTheme.bodyMedium!.copyWith(
+                              color: (textColor ?? context.colorScheme.onSurface).withAlpha(180),
+                            ),
+                          ))
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/components/settings_card.dart
+++ b/lib/screens/settings/components/settings_card.dart
@@ -4,7 +4,6 @@ import 'package:hashed/components/notification_badge.dart';
 import 'package:hashed/domain-shared/ui_constants.dart';
 import 'package:hashed/utils/ThemeBuildContext.dart';
 
-/// SECURITY CARD
 class SettingsCard extends StatelessWidget {
   /// Card icon
   final Widget icon;
@@ -43,7 +42,7 @@ class SettingsCard extends StatelessWidget {
         onTap: onTap,
         child: Ink(
           decoration: BoxDecoration(
-            color: this.backgroundColor ?? context.colorScheme.surface,
+            color: backgroundColor ?? context.colorScheme.surface,
             borderRadius: BorderRadius.circular(defaultCardBorderRadius),
           ),
           child: Row(

--- a/lib/screens/settings/components/settings_card.dart
+++ b/lib/screens/settings/components/settings_card.dart
@@ -21,15 +21,20 @@ class SettingsCard extends StatelessWidget {
   final GestureTapCallback? onTap;
 
   final bool hasNotification;
+  final Color? backgroundColor;
+  final Color? textColor;
 
-  const SettingsCard(
-      {super.key,
-      required this.icon,
-      required this.title,
-      this.description = '',
-      this.titleWidget,
-      this.onTap,
-      this.hasNotification = false});
+  const SettingsCard({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.description = '',
+    this.titleWidget,
+    this.onTap,
+    this.hasNotification = false,
+    this.backgroundColor,
+    this.textColor,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +43,7 @@ class SettingsCard extends StatelessWidget {
         onTap: onTap,
         child: Ink(
           decoration: BoxDecoration(
-            color: context.colorScheme.surface,
+            color: this.backgroundColor ?? context.colorScheme.surface,
             borderRadius: BorderRadius.circular(defaultCardBorderRadius),
           ),
           child: Row(
@@ -67,7 +72,12 @@ class SettingsCard extends StatelessWidget {
                               child: Row(
                                 children: [
                                   Flexible(
-                                    child: Text(title),
+                                    child: Text(
+                                      title,
+                                      style: TextStyle(
+                                        color: textColor ?? context.colorScheme.onSurface,
+                                      ),
+                                    ),
                                   ),
                                   const SizedBox(width: 10),
                                   if (hasNotification) const NotificationBadge()
@@ -82,7 +92,15 @@ class SettingsCard extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.only(bottom: 16, top: 6),
                         child: Row(
-                          children: [Flexible(child: Text(description, style: Theme.of(context).textTheme.subtitle2))],
+                          children: [
+                            Flexible(
+                                child: Text(
+                              description,
+                              style: context.textTheme.subtitle2!.copyWith(
+                                color: (textColor ?? context.colorScheme.onSurface).withAlpha(180),
+                              ),
+                            ))
+                          ],
                         ),
                       ),
                     ],

--- a/lib/screens/settings/interactor/viewmodels/settings_bloc.dart
+++ b/lib/screens/settings/interactor/viewmodels/settings_bloc.dart
@@ -69,7 +69,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   }
 
   Future<void> _onRecoverAccountTapped(OnRecoverAccountTapped event, Emitter<SettingsState> emit) async {
-    emit(state.copyWith(pageCommand: NavigateToRoute(Routes.recoverAccountSearch)));
+    emit(state.copyWith(pageCommand: NavigateToRoute(Routes.recoverAccountOverview)));
   }
 
   void _onPasscodePressed(OnPasscodePressed event, Emitter<SettingsState> emit) {

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -92,7 +92,6 @@ class SettingsScreen extends StatelessWidget {
                           icon: const Icon(Icons.shield),
                           title: "Recover Account",
                           description: "Recover an account with the help of the guardians set for that account.",
-                          // TODO(n13): Fix share secret words
                           onTap: () async {
                             BlocProvider.of<SettingsBloc>(context).add(const OnRecoverAccountTapped());
                           },

--- a/lib/screens/wallet/components/tokens_cards/tokens_cards.dart
+++ b/lib/screens/wallet/components/tokens_cards/tokens_cards.dart
@@ -6,6 +6,7 @@ import 'package:hashed/blocs/deeplink/model/guardian_recovery_request_data.dart'
 import 'package:hashed/blocs/rates/viewmodels/rates_bloc.dart';
 import 'package:hashed/components/dots_indicator.dart';
 import 'package:hashed/datasource/local/account_service.dart';
+import 'package:hashed/datasource/remote/model/active_recovery_model.dart';
 import 'package:hashed/datasource/remote/polkadot_api/polkadot_repository.dart';
 import 'package:hashed/domain-shared/page_state.dart';
 import 'package:hashed/domain-shared/shared_use_cases/cerate_firebase_dynamic_link_use_case.dart';
@@ -85,9 +86,20 @@ class _TokenCardsState extends State<TokenCards> with AutomaticKeepAliveClientMi
                         child: WalletButtons(
                           title: 'Receive',
                           onPressed: () async {
-                            // get last block
-                            final res = await polkadotRepository.getLastBlockNumber();
-                            print("last block: ${res.asValue!.value}");
+                            /// get last block
+                            // final res = await polkadotRepository.getLastBlockNumber();
+                            // print("last block: ${res.asValue!.value}");
+
+                            // get recovery
+                            final lostAccount = "5HGZfBpqUUqGY7uRCYA6aRwnRHJVhrikn8to31GcfNcifkym";
+                            final rescuer = "5G6XUFXZsdUYdB84eEjvPP33tFF1DjbSg7MPsNAx3mVDnxaW";
+                            final res = await polkadotRepository.recoveryRepository
+                                .getActiveRecoveriesForLostaccount(rescuer, lostAccount);
+
+                            final recovery = res.asValue!.value;
+                            print("recovery: ${recovery!.toJson()} ");
+
+                            // print("firebase deep link: ${link.asValue?.value}");
 
                             // create link
                             // final link = await CreateFirebaseDynamicLinkUseCase().createDynamicLink(

--- a/lib/utils/short_string.dart
+++ b/lib/utils/short_string.dart
@@ -1,8 +1,7 @@
 extension ShortString on String {
-
   /// The the first and last 7 characters of the string and ... in the middle
   /// perfect for substrate BIP39 style addresses.
   /// Fixed length of 17 characters
-  /// 
-  String get shorter => "${substring(0, 7)}...${substring(length - 7, length)}";
+  ///
+  String get shorter => length > 17 ? "${substring(0, 7)}...${substring(length - 7, length)}" : this;
 }

--- a/scripts/recovery.js
+++ b/scripts/recovery.js
@@ -755,6 +755,20 @@ const queryActiveRecovery = async () => {
 
 }
 
+const queryProxy = async (api, address) => {
+
+ const res = await api.query.recovery.proxy.entries(address);
+  
+  console.log("proxy for " + address + ": " + JSON.stringify(res, null, 2))
+
+
+  await api.disconnect()
+  console.log("disconnecting done")
+
+  return res
+
+}
+
 const queryActiveRecoveryByRescuer = async (lostAccount, rescuer) => {
   const { api, keyring, steve } = await init()
 
@@ -823,7 +837,7 @@ program
     const result = await createRecovery()
   })
 
-program
+  program
   .command('query_recovery')
   .description('Query recovery')
   .action(async function () {
@@ -831,6 +845,16 @@ program
     console.log("Query recovery...")
 
     const result = await queryRecovery()
+  })
+  program
+  .command('query_proxy')
+  .description('Query proxy')
+  .action(async function () {
+
+    console.log("Query proxy...")
+    const { api, keyring, steve } = await init()
+
+    const result = await queryProxy(api, steve.address)
   })
 
 program


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

As per design spec

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

1 - Testing with mock data for this PR

2 - Added a setting for the currently active recovery "lost account" - this data cannot be retrieved from chain.

It can be retrieved when entering the same account to recover again though, meaning there's only ever one active recovery on chain with a specific rescuer / lost account pair. 

So if I am the same rescuer, and enter the same lost account as on another device, I am getting the same active recovery back
We need to still store this value, next PR


### 🙈 Screenshots

![Simulator Screen Shot - iPhone 13 - 2022-09-28 at 21 50 33](https://user-images.githubusercontent.com/65412/192796514-bb57d04b-0f54-4b9d-b727-5ae3a3a158a2.png)



### 👯‍♀️ Paired with

