### PR TITLE
implement tap on recovered accounts

### DIFF
--- a/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hashed/components/full_page_error_indicator.dart';
 import 'package:hashed/components/full_page_loading_indicator.dart';
 import 'package:hashed/domain-shared/page_state.dart';
+import 'package:hashed/navigation/navigation_service.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart';
 import 'package:hashed/screens/settings/components/account_card.dart';
 import 'package:hashed/screens/settings/components/settings_card.dart';
@@ -62,6 +63,7 @@ class RecoverAccountOverviewView extends StatelessWidget {
                     ),
                   const SizedBox(height: 16),
                   ...state.recoveredAccounts.map((e) => AccountCard(
+                      onTap: () => NavigationService.of(context).navigateTo(Routes.recoverAccountSuccess, e),
                       address: e,
                       icon: const Icon(
                         Icons.bookmark,


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Tapping on a recovered account shows the recover account success actions screen

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Wire up the recovered account card

Tested.

### 🙈 Screenshots


### 👯‍♀️ Paired with

