### PR TITLE
Feature/vouch for recovery implementation

### DIFF
--- a/lib/datasource/remote/api/guardians_repository.dart
+++ b/lib/datasource/remote/api/guardians_repository.dart
@@ -48,7 +48,7 @@ class GuardiansRepository with HttpRepository {
   Future<Result> recoverAccount({required String lostAccount, required String rescuerAccount}) async {
     // This will need to be removed - works different on Polkadot / Subsrate
     return polkadotRepository.recoveryRepository.vouch(
-        address: accountService.currentAccount.address, lostAccount: lostAccount, recovererAccount: rescuerAccount);
+        account: accountService.currentAccount.address, lostAccount: lostAccount, recovererAccount: rescuerAccount);
   }
 
   Future<Result<List<ActiveRecoveryModel>>> getAccountRecovery(String lostAccountName) async {

--- a/lib/datasource/remote/model/active_recovery_model.dart
+++ b/lib/datasource/remote/model/active_recovery_model.dart
@@ -1,6 +1,8 @@
+import 'package:equatable/equatable.dart';
+
 /// Represents an active recovery
 ///
-class ActiveRecoveryModel {
+class ActiveRecoveryModel extends Equatable {
   /// the account it is trying to recover
   final String lostAccount;
 
@@ -16,7 +18,11 @@ class ActiveRecoveryModel {
   /// the list of friends / guardians who have already signed - can be empty
   final List<String> friends;
 
-  ActiveRecoveryModel({
+  bool get isEmpty => this == ActiveRecoveryModel.empty;
+
+  bool get isNotEmpty => !isEmpty;
+
+  const ActiveRecoveryModel({
     required this.lostAccount,
     required this.rescuer,
     required this.created,
@@ -74,13 +80,24 @@ class ActiveRecoveryModel {
     };
   }
 
-  static final mock = ActiveRecoveryModel(
+  static final mock = const ActiveRecoveryModel(
     lostAccount: "5HGZfBpqUUqGY7uRCYA6aRwnRHJVhrikn8to31GcfNcifkym",
     rescuer: "5G6XUFXZsdUYdB84eEjvPP33tFF1DjbSg7MPsNAx3mVDnxaW",
     created: 1035220,
     deposit: 16666666500,
     friends: ["5G6XUFXZsdUYdB84eEjvPP33tFF1DjbSg7MPsNAx3mVDnxaW"],
   );
+
+  static final empty = const ActiveRecoveryModel(
+    lostAccount: "",
+    rescuer: "",
+    created: 0,
+    deposit: 0,
+    friends: [],
+  );
+
+  @override
+  List<Object?> get props => [lostAccount, rescuer, created, deposit, friends];
 }
 
 // flutter: getRecoveryConfig res: [{

--- a/lib/datasource/remote/model/guardians_config_model.dart
+++ b/lib/datasource/remote/model/guardians_config_model.dart
@@ -8,6 +8,8 @@ class GuardiansConfigModel {
 
   bool get isEmpty => guardians.isEmpty;
 
+  bool get isNotEmpty => !isEmpty;
+
   int get length => guardians.length;
 
   List<String> get guardianAddresses => guardians.map((e) => e.address).toList();

--- a/lib/datasource/remote/polkadot_api/recovery_repository.dart
+++ b/lib/datasource/remote/polkadot_api/recovery_repository.dart
@@ -138,7 +138,7 @@ class RecoveryRepository extends ExtrinsicsRepository {
     }
   }
 
-  Future<Result<ActiveRecoveryModel?>> getActiveRecoveriesForLostaccount({
+  Future<Result<ActiveRecoveryModel>> getActiveRecoveriesForLostaccount({
     required String rescuer,
     required String lostAccount,
     bool mock = false,
@@ -154,7 +154,7 @@ class RecoveryRepository extends ExtrinsicsRepository {
       final res = await evalJavascript(code: code);
 
       if (res == null) {
-        return Result.value(null);
+        return Result.value(ActiveRecoveryModel.empty);
       }
 
       final recovery = ActiveRecoveryModel.fromJsonSingle(rescuer: rescuer, lostAccount: lostAccount, json: res);

--- a/lib/datasource/remote/polkadot_api/recovery_repository.dart
+++ b/lib/datasource/remote/polkadot_api/recovery_repository.dart
@@ -168,9 +168,9 @@ class RecoveryRepository extends ExtrinsicsRepository {
   }
 
   Future<Result<dynamic>> vouch(
-      {required String address, required String lostAccount, required String recovererAccount}) async {
+      {required String account, required String lostAccount, required String recovererAccount}) async {
     print('vouch for $recovererAccount recovering $lostAccount');
-    final sender = TxSenderData(address);
+    final sender = TxSenderData(account);
     final txInfo = SubstrateTransactionModel(module: 'recovery', call: 'vouchRecovery', sender: sender);
     final params = [lostAccount, recovererAccount];
     try {

--- a/lib/domain-shared/event_bus/events.dart
+++ b/lib/domain-shared/event_bus/events.dart
@@ -29,6 +29,10 @@ class OnConnectionStateEventBus extends BusEvent<OnConnectionStateEventBus> {
   const OnConnectionStateEventBus(this.connected);
 }
 
+class OnRecoverDataChangedEventBus extends BusEvent<OnRecoverDataChangedEventBus> {
+  const OnRecoverDataChangedEventBus();
+}
+
 class ShowSnackBar extends BusEvent<OnNewTransactionEventBus> {
   final String message;
   final SnackType snackType;

--- a/lib/domain-shared/shared_use_cases/get_active_recovery_for_lost_account_use_case.dart
+++ b/lib/domain-shared/shared_use_cases/get_active_recovery_for_lost_account_use_case.dart
@@ -3,7 +3,7 @@ import 'package:hashed/datasource/remote/polkadot_api/polkadot_repository.dart';
 import 'package:hashed/utils/result_extension.dart';
 
 class GetActiveRecoveryForLostAccountUseCase {
-  Future<Result<ActiveRecoveryModel?>> run({required String rescuer, required String lostAccount}) {
+  Future<Result<ActiveRecoveryModel>> run({required String rescuer, required String lostAccount}) {
     return polkadotRepository.recoveryRepository
         .getActiveRecoveriesForLostaccount(rescuer: rescuer, lostAccount: lostAccount);
   }

--- a/lib/screens/app/interactor/usecases/approve_guardian_recovery_use_case.dart
+++ b/lib/screens/app/interactor/usecases/approve_guardian_recovery_use_case.dart
@@ -1,20 +1,13 @@
 import 'package:async/async.dart';
-// import 'package:hashed/datasource/remote/api/guardians_repository.dart';
-// import 'package:hashed/datasource/remote/firebase/firebase_database_guardians_repository.dart';
+import 'package:hashed/datasource/remote/polkadot_api/polkadot_repository.dart';
 
 class ApproveGuardianRecoveryUseCase {
-  // final GuardiansRepository _guardiansRepository = GuardiansRepository();
-  // final FirebaseDatabaseGuardiansRepository _databaseGuardiansRepository = FirebaseDatabaseGuardiansRepository();
-
-  Future<Result> approveGuardianRecovery(String userAccount, String publicKey) async {
-    throw UnimplementedError("not sure we need this");
-    // final result = await _guardiansRepository.recoverAccount(userAccount, publicKey);
-
-    // // If recover call success, Init the firebase recovery flag.
-    // if (result.isValue) {
-    //   await _databaseGuardiansRepository.setGuardianRecoveryStarted(userAccount);
-    // }
-
-    // return result;
+  Future<Result<dynamic>> approveGuardianRecovery(
+      {required String account, required String lostAccount, required String rescuer}) async {
+    return polkadotRepository.recoveryRepository.vouch(
+      account: account,
+      lostAccount: lostAccount,
+      recovererAccount: rescuer,
+    );
   }
 }

--- a/lib/screens/app/interactor/viewmodels/app_bloc.dart
+++ b/lib/screens/app/interactor/viewmodels/app_bloc.dart
@@ -4,9 +4,12 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:hashed/blocs/deeplink/model/guardian_recovery_request_data.dart';
 import 'package:hashed/blocs/deeplink/viewmodels/deeplink_bloc.dart';
+import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/datasource/local/models/scan_qr_code_result_data.dart';
 import 'package:hashed/domain-shared/page_command.dart';
 import 'package:hashed/domain-shared/page_state.dart';
+import 'package:hashed/screens/app/interactor/mappers/approve_guardian_recovery_state_mapper.dart';
+import 'package:hashed/screens/app/interactor/usecases/approve_guardian_recovery_use_case.dart';
 import 'package:hashed/screens/app/interactor/viewmodels/app_page_commands.dart';
 
 part 'app_event.dart';
@@ -87,17 +90,14 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     _deeplinkBloc.add(const OnGuardianRecoveryRequestSeen());
     emit(state.copyWith(pageState: PageState.loading));
 
-    /// this should simply take the data - lostAccount and rescuer - and vouch.
-    ///
-
     print("recovery vouch: ${event.data.rescuer} lost: ${event.data.lostAccount}");
-    print("Not yet implemented");
 
-    throw UnimplementedError("implement this or remove.");
-
-    // final result = await ApproveGuardianRecoveryUseCase()
-    //     .approveGuardianRecovery(lostAccount: event.data.lostAccount, rescuer: event.data.rescuer);
-    // emit(ApproveGuardianRecoveryStateMapper().mapResultToState(state, result));
+    final result = await ApproveGuardianRecoveryUseCase().approveGuardianRecovery(
+      account: accountService.currentAccount.address,
+      lostAccount: event.data.lostAccount,
+      rescuer: event.data.rescuer,
+    );
+    emit(ApproveGuardianRecoveryStateMapper().mapResultToState(state, result));
   }
 
   void _onApproveGuardianRecoveryDeepLink(OnApproveGuardianRecoveryDeepLink event, Emitter<AppState> emit) {

--- a/lib/screens/authentication/recover/recover_account_details/interactor/usecase/fetch_recover_account_details_data.dart
+++ b/lib/screens/authentication/recover/recover_account_details/interactor/usecase/fetch_recover_account_details_data.dart
@@ -53,7 +53,7 @@ class FetchRecoverAccountDetailsUsecase {
 class RecoveryResultData {
   final Uri linkToActivateGuardians;
   final GuardiansConfigModel configuration;
-  final ActiveRecoveryModel? activeRecovery;
+  final ActiveRecoveryModel activeRecovery;
 
   RecoveryResultData({
     required this.linkToActivateGuardians,

--- a/lib/screens/authentication/recover/recover_account_details/interactor/viewmodels/recover_account_details_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_details/interactor/viewmodels/recover_account_details_bloc.dart
@@ -28,12 +28,12 @@ class RecoverAccountDetailsBloc extends Bloc<RecoverAccountDetailsEvent, Recover
       emit(state.copyWith(
         linkToActivateGuardians: data.linkToActivateGuardians,
         totalGuardiansCount: data.configuration.guardianAddresses.length,
-        approvedAccounts: data.activeRecovery?.friends,
+        approvedAccounts: data.activeRecovery.friends,
         guardianAccounts: data.configuration.guardianAddresses,
         threshold: data.configuration.threshold,
         pageState: PageState.success,
       ));
-      if (data.activeRecovery != null && data.activeRecovery!.friends.length >= data.configuration.threshold) {
+      if (data.activeRecovery.isNotEmpty && data.activeRecovery.friends.length >= data.configuration.threshold) {
         emit(state.copyWith(
             pageCommand: NavigateToRouteWithArguments(route: Routes.recoverAccountTimer, arguments: data)));
       }

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
@@ -44,7 +44,7 @@ class RecoverAccountOverviewView extends StatelessWidget {
                     },
                   ),
                   const SizedBox(height: 16),
-                  if (state.activeRecovery.isNotEmpty) ...[
+                  if (state.showActiveRecovery && state.activeRecovery.isNotEmpty) ...[
                     SettingsCard(
                         backgroundColor: context.colorScheme.tertiaryContainer,
                         textColor: context.colorScheme.onTertiaryContainer,

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/components/recover_account_overview_view.dart
@@ -44,16 +44,16 @@ class RecoverAccountOverviewView extends StatelessWidget {
                     },
                   ),
                   const SizedBox(height: 16),
-                  if (state.activeRecovery != null) ...[
+                  if (state.activeRecovery.isNotEmpty) ...[
                     SettingsCard(
                         backgroundColor: context.colorScheme.tertiaryContainer,
                         textColor: context.colorScheme.onTertiaryContainer,
                         icon: const Icon(Icons.keyboard_command_key),
                         title: "Recovery in Process",
-                        description: "Recovering    ${state.activeRecovery!.lostAccount.shorter}",
+                        description: "Recovering    ${state.activeRecovery.lostAccount.shorter}",
                         onTap: () async {
                           BlocProvider.of<RecoverAccountOverviewBloc>(context)
-                              .add(OnRecoveryInProcessTapped(state.activeRecovery!.lostAccount));
+                              .add(OnRecoveryInProcessTapped(state.activeRecovery.lostAccount));
                         }),
                     const SizedBox(height: 16)
                   ],

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/usecase/fetch_recover_account_overview_data.dart
@@ -12,7 +12,7 @@ class FetchRecoverAccountOverviewUsecase {
       return Result.value(RecoveryOverviewData.mock);
     }
 
-    Result<ActiveRecoveryModel?>? activeResult;
+    Result<ActiveRecoveryModel>? activeResult;
 
     if (lostAccount != null) {
       activeResult = await polkadotRepository.recoveryRepository

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
@@ -5,6 +5,8 @@ import 'package:equatable/equatable.dart';
 import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/datasource/local/settings_storage.dart';
 import 'package:hashed/datasource/remote/model/active_recovery_model.dart';
+import 'package:hashed/domain-shared/event_bus/event_bus.dart';
+import 'package:hashed/domain-shared/event_bus/events.dart';
 import 'package:hashed/domain-shared/page_command.dart';
 import 'package:hashed/domain-shared/page_state.dart';
 import 'package:hashed/navigation/navigation_service.dart';
@@ -15,7 +17,20 @@ part 'recover_account_overview_event.dart';
 part 'recover_account_overview_state.dart';
 
 class RecoverAccountOverviewBloc extends Bloc<RecoverAccountOverviewEvent, RecoverAccountOverviewState> {
+  StreamSubscription? eventBusSubscription;
+
+  @override
+  Future<void> close() async {
+    await eventBusSubscription?.cancel();
+    return super.close();
+  }
+
   RecoverAccountOverviewBloc() : super(RecoverAccountOverviewState.initial()) {
+    eventBusSubscription = eventBus.on().listen((event) async {
+      if (event is OnRecoverDataChangedEventBus) {
+        add(const OnRefreshTapped());
+      }
+    });
     on<FetchInitialData>(_fetchInitialData);
     on<OnRefreshTapped>(_onRefreshTapped);
     on<OnRecoverAccountTapped>(_onRecoverAccountTapped);

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart
@@ -44,12 +44,19 @@ class RecoverAccountOverviewBloc extends Bloc<RecoverAccountOverviewEvent, Recov
       accountService.currentAccount.address,
       lostAccount: activeRecoveryAccount,
     );
+    bool showActiveRecovery = false;
 
     if (result.isValue) {
+      if (result.asValue!.value.activeRecovery != null) {
+        final lostAccount = result.asValue!.value.activeRecovery!.lostAccount;
+        showActiveRecovery = !result.asValue!.value.proxyAccounts.contains(lostAccount);
+      }
+
       emit(state.copyWith(
         pageState: PageState.success,
         activeRecovery: result.asValue!.value.activeRecovery,
         recoveredAccounts: result.asValue!.value.proxyAccounts,
+        showActiveRecovery: showActiveRecovery,
       ));
     } else {
       print("Error ${result.asError!.error}");

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_state.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_state.dart
@@ -3,13 +3,13 @@ part of 'recover_account_overview_bloc.dart';
 class RecoverAccountOverviewState extends Equatable {
   final PageState pageState;
   final PageCommand? pageCommand;
-  final ActiveRecoveryModel? activeRecovery;
+  final ActiveRecoveryModel activeRecovery;
   final List<String> recoveredAccounts;
 
   const RecoverAccountOverviewState({
     required this.pageState,
     this.pageCommand,
-    this.activeRecovery,
+    required this.activeRecovery,
     this.recoveredAccounts = const [],
   });
 
@@ -36,8 +36,9 @@ class RecoverAccountOverviewState extends Equatable {
   }
 
   factory RecoverAccountOverviewState.initial() {
-    return const RecoverAccountOverviewState(
+    return RecoverAccountOverviewState(
       pageState: PageState.initial,
+      activeRecovery: ActiveRecoveryModel.empty,
     );
   }
 }

--- a/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_state.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_state.dart
@@ -5,12 +5,14 @@ class RecoverAccountOverviewState extends Equatable {
   final PageCommand? pageCommand;
   final ActiveRecoveryModel activeRecovery;
   final List<String> recoveredAccounts;
+  final bool showActiveRecovery;
 
   const RecoverAccountOverviewState({
     required this.pageState,
     this.pageCommand,
     required this.activeRecovery,
     this.recoveredAccounts = const [],
+    this.showActiveRecovery = false,
   });
 
   @override
@@ -19,6 +21,7 @@ class RecoverAccountOverviewState extends Equatable {
         pageCommand,
         activeRecovery,
         recoveredAccounts,
+        showActiveRecovery,
       ];
 
   RecoverAccountOverviewState copyWith({
@@ -26,12 +29,14 @@ class RecoverAccountOverviewState extends Equatable {
     PageCommand? pageCommand,
     ActiveRecoveryModel? activeRecovery,
     List<String>? recoveredAccounts,
+    bool? showActiveRecovery,
   }) {
     return RecoverAccountOverviewState(
       pageState: pageState ?? this.pageState,
       pageCommand: pageCommand,
       activeRecovery: activeRecovery ?? this.activeRecovery,
       recoveredAccounts: recoveredAccounts ?? this.recoveredAccounts,
+      showActiveRecovery: showActiveRecovery ?? this.showActiveRecovery,
     );
   }
 

--- a/lib/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart
+++ b/lib/screens/authentication/recover/recover_account_overview/recover_account_overview_page.dart
@@ -27,7 +27,7 @@ class RecoverAccountOverviewPage extends StatelessWidget {
             builder: (BuildContext context, RecoverAccountOverviewState state) {
           return Scaffold(
               appBar: AppBar(
-                title: const Padding(padding: EdgeInsets.only(left: 16), child: Text("Recovery")),
+                title: const Padding(padding: EdgeInsets.only(left: 16), child: Text('Recovery')),
                 automaticallyImplyLeading: false,
                 leading: Padding(
                   padding: const EdgeInsets.all(8.0),

--- a/lib/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_search_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_search_bloc.dart
@@ -47,6 +47,7 @@ class RecoverAccountSearchBloc extends Bloc<RecoverAccountSearchEvent, RecoverAc
     if (existing.isValue && existing.asValue!.value is ActiveRecoveryModel) {
       /// A recovery for this rescuer, lost account already exists
       print("rexocery exists: ");
+      settingsStorage.activeRecoveryAccount = lostAccount;
       emit(state.copyWith(isNextLoading: false));
 
       emit(state.copyWith(

--- a/lib/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_search_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_search_bloc.dart
@@ -4,7 +4,6 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/datasource/local/settings_storage.dart';
-import 'package:hashed/datasource/remote/model/active_recovery_model.dart';
 import 'package:hashed/datasource/remote/polkadot_api/polkadot_repository.dart';
 import 'package:hashed/domain-shared/page_command.dart';
 import 'package:hashed/domain-shared/page_state.dart';
@@ -44,7 +43,7 @@ class RecoverAccountSearchBloc extends Bloc<RecoverAccountSearchEvent, RecoverAc
     final existing = await _polkadotRepository.recoveryRepository
         .getActiveRecoveriesForLostaccount(rescuer: address, lostAccount: lostAccount);
 
-    if (existing.isValue && existing.asValue!.value is ActiveRecoveryModel) {
+    if (existing.isValue && existing.asValue!.value.isNotEmpty) {
       /// A recovery for this rescuer, lost account already exists
       print("rexocery exists: ");
       settingsStorage.activeRecoveryAccount = lostAccount;

--- a/lib/screens/authentication/recover/recover_account_search/recover_account_screen.dart
+++ b/lib/screens/authentication/recover/recover_account_search/recover_account_screen.dart
@@ -10,7 +10,6 @@ import 'package:hashed/domain-shared/event_bus/events.dart';
 import 'package:hashed/domain-shared/page_command.dart';
 import 'package:hashed/domain-shared/ui_constants.dart';
 import 'package:hashed/navigation/navigation_service.dart';
-import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_search/components/recover_account_confimation_dialog.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_page_command.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_search_bloc.dart';

--- a/lib/screens/authentication/recover/recover_account_search/recover_account_screen.dart
+++ b/lib/screens/authentication/recover/recover_account_search/recover_account_screen.dart
@@ -51,7 +51,6 @@ class _RecoverAccountScreenState extends State<RecoverAccountScreen> {
           } else if (pageCommand is ShowErrorMessage) {
             eventBus.fire(ShowSnackBar(pageCommand.message));
           } else if (pageCommand is NavigateToRouteWithArguments) {
-            BlocProvider.of<RecoverAccountOverviewBloc>(context).add(const OnRefreshTapped());
             NavigationService.of(context).navigateTo(
               pageCommand.route,
               arguments: pageCommand.arguments,

--- a/lib/screens/authentication/recover/recover_account_search/recover_account_screen.dart
+++ b/lib/screens/authentication/recover/recover_account_search/recover_account_screen.dart
@@ -10,6 +10,7 @@ import 'package:hashed/domain-shared/event_bus/events.dart';
 import 'package:hashed/domain-shared/page_command.dart';
 import 'package:hashed/domain-shared/ui_constants.dart';
 import 'package:hashed/navigation/navigation_service.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_overview/interactor/viewmodels/recover_account_overview_bloc.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_search/components/recover_account_confimation_dialog.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_page_command.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_search/interactor/viewmodels/recover_account_search_bloc.dart';
@@ -50,7 +51,12 @@ class _RecoverAccountScreenState extends State<RecoverAccountScreen> {
           } else if (pageCommand is ShowErrorMessage) {
             eventBus.fire(ShowSnackBar(pageCommand.message));
           } else if (pageCommand is NavigateToRouteWithArguments) {
-            NavigationService.of(context).navigateTo(pageCommand.route, arguments: pageCommand.arguments);
+            BlocProvider.of<RecoverAccountOverviewBloc>(context).add(const OnRefreshTapped());
+            NavigationService.of(context).navigateTo(
+              pageCommand.route,
+              arguments: pageCommand.arguments,
+              replace: true,
+            );
           }
         },
         builder: (context, state) {

--- a/lib/screens/authentication/recover/recover_account_success/components/recover_account_success_view.dart
+++ b/lib/screens/authentication/recover/recover_account_success/components/recover_account_success_view.dart
@@ -61,7 +61,7 @@ class RecoverAccountSuccessView extends StatelessWidget {
                         ));
                       },
                     ),
-                    if (state.activeRecoveryModel != null) ...[
+                    if (state.activeRecoveryModel.isNotEmpty) ...[
                       const SizedBox(height: 10),
                       SettingsCard(
                         icon: const Icon(Icons.delete_forever),

--- a/lib/screens/authentication/recover/recover_account_success/components/recover_account_success_view.dart
+++ b/lib/screens/authentication/recover/recover_account_success/components/recover_account_success_view.dart
@@ -72,7 +72,7 @@ class RecoverAccountSuccessView extends StatelessWidget {
                         },
                       ),
                     ],
-                    if (!state.guardiansConfig.isEmpty) ...[
+                    if (state.guardiansConfig.isNotEmpty) ...[
                       const SizedBox(height: 10),
                       SettingsCard(
                         icon: const Icon(Icons.clear_rounded),

--- a/lib/screens/authentication/recover/recover_account_success/components/recover_account_success_view.dart
+++ b/lib/screens/authentication/recover/recover_account_success/components/recover_account_success_view.dart
@@ -7,6 +7,7 @@ import 'package:hashed/components/full_page_error_indicator.dart';
 import 'package:hashed/components/full_page_loading_indicator.dart';
 import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/domain-shared/page_state.dart';
+import 'package:hashed/navigation/navigation_service.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_page_command.dart';
 import 'package:hashed/screens/settings/components/settings_card.dart';
@@ -104,8 +105,7 @@ class RecoverAccountSuccessView extends StatelessWidget {
       builder: (context) {
         return CustomDialog(
           onSingleLargeButtonPressed: () {
-            Navigator.pop(context);
-            Navigator.pop(context);
+            Navigator.popUntil(context, (route) => route.settings.name == Routes.recoverAccountOverview);
           },
           icon: SvgPicture.asset('assets/images/security/success_outlined_icon.svg'),
           singleLargeButtonTitle: "Done",

--- a/lib/screens/authentication/recover/recover_account_success/components/recover_account_success_view.dart
+++ b/lib/screens/authentication/recover/recover_account_success/components/recover_account_success_view.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:hashed/components/custom_dialog.dart';
 import 'package:hashed/components/flat_button_long_outlined.dart';
 import 'package:hashed/components/full_page_error_indicator.dart';
 import 'package:hashed/components/full_page_loading_indicator.dart';
 import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/domain-shared/page_state.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_page_command.dart';
 import 'package:hashed/screens/settings/components/settings_card.dart';
 import 'package:hashed/utils/short_string.dart';
 
@@ -14,7 +17,15 @@ class RecoverAccountSuccessView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<RecoverAccountSuccessBloc, RecoverAccountSuccessState>(
+    // return BlocBuilder<RecoverAccountSuccessBloc, RecoverAccountSuccessState>(
+    return BlocConsumer<RecoverAccountSuccessBloc, RecoverAccountSuccessState>(
+      listenWhen: (_, current) => current.pageCommand != null,
+      listener: (context, state) async {
+        final pageCommand = state.pageCommand;
+        if (pageCommand is ShowCancelCompleteDialogPageCommand) {
+          _showCancelCompleteDialog(context);
+        }
+      },
       builder: (context, state) {
         switch (state.pageState) {
           case PageState.loading:
@@ -83,6 +94,29 @@ class RecoverAccountSuccessView extends StatelessWidget {
               ),
             );
         }
+      },
+    );
+  }
+
+  void _showCancelCompleteDialog(BuildContext buildContext) {
+    showDialog(
+      context: buildContext,
+      builder: (context) {
+        return CustomDialog(
+          onSingleLargeButtonPressed: () {
+            Navigator.pop(context);
+            Navigator.pop(context);
+          },
+          icon: SvgPicture.asset('assets/images/security/success_outlined_icon.svg'),
+          singleLargeButtonTitle: "Done",
+          children: [
+            const SizedBox(height: 10),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [const Text("Recovery closed successfully!")],
+            ),
+          ],
+        );
       },
     );
   }

--- a/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart
@@ -42,10 +42,10 @@ class RecoverAccountSuccessBloc extends Bloc<RecoverAccountSuccessEvent, Recover
     ]);
     final balanceResult = res[0] as Result<BalanceModel>;
     final configResult = res[1] as Result<GuardiansConfigModel>;
-    final activeResult = res[2] as Result<ActiveRecoveryModel?>;
+    final activeResult = res[2] as Result<ActiveRecoveryModel>;
 
-    final config = configResult.isValue ? configResult.asValue!.value : null;
-    final active = activeResult.isValue ? activeResult.asValue!.value : null;
+    final config = configResult.isValue ? configResult.asValue!.value : GuardiansConfigModel.empty();
+    final active = activeResult.isValue ? activeResult.asValue!.value : ActiveRecoveryModel.empty;
 
     if (balanceResult.isValue) {
       final data = balanceResult.asValue!.value;

--- a/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart
@@ -4,6 +4,7 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:hashed/datasource/local/account_service.dart';
 import 'package:hashed/datasource/local/models/token_data_model.dart';
+import 'package:hashed/datasource/local/settings_storage.dart';
 import 'package:hashed/datasource/remote/model/active_recovery_model.dart';
 import 'package:hashed/datasource/remote/model/balance_model.dart';
 import 'package:hashed/datasource/remote/model/guardians_config_model.dart';
@@ -142,6 +143,7 @@ class RecoverAccountSuccessBloc extends Bloc<RecoverAccountSuccessEvent, Recover
 
     if (res.isValue) {
       print("remove active recovery ${res.asValue!.value}");
+      settingsStorage.activeRecoveryAccount = null;
       emit(state.copyWith(pageState: PageState.success, guardiansConfig: GuardiansConfigModel.empty()));
       add(const OnRefreshTapped());
       eventBus.fire(const OnWalletRefreshEventBus());

--- a/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart
@@ -101,6 +101,7 @@ class RecoverAccountSuccessBloc extends Bloc<RecoverAccountSuccessEvent, Recover
       ));
       add(const OnRefreshTapped());
       eventBus.fire(const OnWalletRefreshEventBus());
+      eventBus.fire(const OnRecoverDataChangedEventBus());
     } else {
       print("cancel fail with error ${res.asError!.error}");
       emit(state.copyWith(pageState: PageState.failure));
@@ -122,6 +123,7 @@ class RecoverAccountSuccessBloc extends Bloc<RecoverAccountSuccessEvent, Recover
       emit(state.copyWith(pageState: PageState.success, guardiansConfig: GuardiansConfigModel.empty()));
       add(const OnRefreshTapped());
       eventBus.fire(const OnWalletRefreshEventBus());
+      eventBus.fire(const OnRecoverDataChangedEventBus());
     } else {
       print("remove config fail with error ${res.asError!.error}");
       emit(state.copyWith(pageState: PageState.failure));
@@ -143,6 +145,7 @@ class RecoverAccountSuccessBloc extends Bloc<RecoverAccountSuccessEvent, Recover
       emit(state.copyWith(pageState: PageState.success, guardiansConfig: GuardiansConfigModel.empty()));
       add(const OnRefreshTapped());
       eventBus.fire(const OnWalletRefreshEventBus());
+      eventBus.fire(const OnRecoverDataChangedEventBus());
     } else {
       print("remove active recovery fail with error ${res.asError!.error}");
       emit(state.copyWith(pageState: PageState.failure));

--- a/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart
+++ b/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_bloc.dart
@@ -14,6 +14,7 @@ import 'package:hashed/domain-shared/event_bus/events.dart';
 import 'package:hashed/domain-shared/page_command.dart';
 import 'package:hashed/domain-shared/page_state.dart';
 import 'package:hashed/domain-shared/shared_use_cases/get_active_recovery_for_lost_account_use_case.dart';
+import 'package:hashed/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_page_command.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_success/usecase/fetch_recover_account_success_data.dart';
 import 'package:hashed/screens/profile_screens/guardians/guardians_tabs/interactor/usecases/get_guardians_data_usecase.dart';
 
@@ -94,7 +95,10 @@ class RecoverAccountSuccessBloc extends Bloc<RecoverAccountSuccessEvent, Recover
 
     if (res.isValue) {
       print("cancel success ${res.asValue!.value}");
-      emit(state.copyWith(pageState: PageState.success));
+      emit(state.copyWith(
+        pageState: PageState.success,
+        pageCommand: ShowCancelCompleteDialogPageCommand(),
+      ));
       add(const OnRefreshTapped());
       eventBus.fire(const OnWalletRefreshEventBus());
     } else {

--- a/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_page_command.dart
+++ b/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_page_command.dart
@@ -1,3 +1,3 @@
 import 'package:hashed/domain-shared/page_command.dart';
 
-class OnXXX extends PageCommand {}
+class ShowCancelCompleteDialogPageCommand extends PageCommand {}

--- a/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_state.dart
+++ b/lib/screens/authentication/recover/recover_account_success/interactor/viewmodels/recover_account_success_state.dart
@@ -5,7 +5,7 @@ class RecoverAccountSuccessState extends Equatable {
   final String lostAccount;
   final TokenDataModel recoverAmount;
   final PageCommand? pageCommand;
-  final ActiveRecoveryModel? activeRecoveryModel;
+  final ActiveRecoveryModel activeRecoveryModel;
   final GuardiansConfigModel guardiansConfig;
 
   const RecoverAccountSuccessState({
@@ -13,7 +13,7 @@ class RecoverAccountSuccessState extends Equatable {
     required this.lostAccount,
     this.pageCommand,
     required this.recoverAmount,
-    this.activeRecoveryModel,
+    required this.activeRecoveryModel,
     required this.guardiansConfig,
   });
 
@@ -48,6 +48,7 @@ class RecoverAccountSuccessState extends Equatable {
       lostAccount: lostAccount,
       recoverAmount: TokenDataModel(0),
       guardiansConfig: GuardiansConfigModel.empty(),
+      activeRecoveryModel: ActiveRecoveryModel.empty,
     );
   }
 }

--- a/lib/screens/authentication/recover/recover_account_timer/recover_account_timer_page.dart
+++ b/lib/screens/authentication/recover/recover_account_timer/recover_account_timer_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:hashed/datasource/local/settings_storage.dart';
 import 'package:hashed/domain-shared/event_bus/event_bus.dart';
 import 'package:hashed/domain-shared/event_bus/events.dart';
 import 'package:hashed/navigation/navigation_service.dart';
@@ -54,8 +53,6 @@ class RecoverAccountTimerPage extends StatelessWidget {
       builder: (context) {
         return RecoverSuccessDialog(
           onDismiss: () {
-            /// recovery has finished
-            settingsStorage.activeRecoveryAccount = null;
             Navigator.popUntil(context, (route) => route.settings.name == Routes.recoverAccountOverview);
             NavigationService.of(context).navigateTo(Routes.recoverAccountSuccess, arguments: lostAccount);
             eventBus.fire(const OnRecoverDataChangedEventBus());

--- a/lib/screens/authentication/recover/recover_account_timer/recover_account_timer_page.dart
+++ b/lib/screens/authentication/recover/recover_account_timer/recover_account_timer_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hashed/datasource/local/settings_storage.dart';
+import 'package:hashed/domain-shared/event_bus/event_bus.dart';
+import 'package:hashed/domain-shared/event_bus/events.dart';
 import 'package:hashed/navigation/navigation_service.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_details/interactor/usecase/fetch_recover_account_details_data.dart';
 import 'package:hashed/screens/authentication/recover/recover_account_timer/components/recover_account_timer_view.dart';
@@ -16,7 +18,7 @@ class RecoverAccountTimerPage extends StatelessWidget {
     // ignore: cast_nullable_to_non_nullable
     final RecoveryResultData recoveryData = ModalRoute.of(context)!.settings.arguments as RecoveryResultData;
     return BlocProvider(
-        create: (context) => RecoverAccountTimerBloc(recoveryData.activeRecovery!, recoveryData.configuration)
+        create: (context) => RecoverAccountTimerBloc(recoveryData.activeRecovery, recoveryData.configuration)
           ..add(const FetchTimerData()),
         child: BlocListener<RecoverAccountTimerBloc, RecoverAccountTimerState>(
           listenWhen: (_, current) => current.pageCommand != null,
@@ -54,8 +56,9 @@ class RecoverAccountTimerPage extends StatelessWidget {
           onDismiss: () {
             /// recovery has finished
             settingsStorage.activeRecoveryAccount = null;
-            NavigationService.of(context)
-                .navigateTo(Routes.recoverAccountSuccess, arguments: lostAccount, replace: true);
+            Navigator.popUntil(context, (route) => route.settings.name == Routes.recoverAccountOverview);
+            NavigationService.of(context).navigateTo(Routes.recoverAccountSuccess, arguments: lostAccount);
+            eventBus.fire(const OnRecoverDataChangedEventBus());
           },
         );
       },

--- a/lib/screens/profile_screens/guardians/guardians_tabs/interactor/viewmodels/guardians_bloc.dart
+++ b/lib/screens/profile_screens/guardians/guardians_tabs/interactor/viewmodels/guardians_bloc.dart
@@ -56,9 +56,9 @@ class GuardiansBloc extends Bloc<GuardiansEvent, GuardiansState> {
       final guardiansModel = result.asValue!.value;
       emit(state.copyWith(
         myGuardians: guardiansModel,
-        areGuardiansActive: !guardiansModel.isEmpty,
+        areGuardiansActive: guardiansModel.isNotEmpty,
         actionButtonState: getActionButtonState(
-          areGuardiansActive: !guardiansModel.isEmpty,
+          areGuardiansActive: guardiansModel.isNotEmpty,
           guardiansCount: guardiansModel.length,
         ),
         pageState: PageState.success,

--- a/lib/screens/wallet/components/tokens_cards/tokens_cards.dart
+++ b/lib/screens/wallet/components/tokens_cards/tokens_cards.dart
@@ -83,13 +83,17 @@ class _TokenCardsState extends State<TokenCards> with AutomaticKeepAliveClientMi
                           title: 'Receive',
                           onPressed: () async {
                             final address = "5HGZfBpqUUqGY7uRCYA6aRwnRHJVhrikn8to31GcfNcifkym";
+                            final valid = await polkadotRepository.validateAddress(address);
+                            print("is valud: $valid");
+
+                            // final address = "5HGZfBpqUUqGY7uRCYA6aRwnRHJVhrikn8to31GcfNcifkym";
 
                             // final address = "5DDEc9t4iZYb4aQ7Gqzxvda6MkRQDQM3WDPJeK1bb5h8LFVb";
-                            final res = await polkadotRepository.recoveryRepository.getProxies(address);
+                            // final res = await polkadotRepository.recoveryRepository.getProxies(address);
 
-                            final recovery = res.asValue!.value;
-                            // ignore: unnecessary_brace_in_string_interps
-                            print("recovery: ${recovery} ");
+                            // final recovery = res.asValue!.value;
+                            // // ignore: unnecessary_brace_in_string_interps
+                            // print("recovery: ${recovery} ");
 
                             /// get last block
                             // final res = await polkadotRepository.getLastBlockNumber();

--- a/scripts/recovery.js
+++ b/scripts/recovery.js
@@ -788,6 +788,10 @@ const queryProxy = async (api, address) => {
   console.log("proxy res: " + JSON.stringify(res, null, 2))
 
 
+  // single entry recoverer - steve - 
+  const resSingle = await api.query.recovery.proxy(process.env.RESCUER_ADDRESS);
+
+  console.log("res single: " + JSON.stringify(resSingle, null, 2))
 
   await api.disconnect()
   console.log("disconnecting done")


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Handle recovery link and vouch
Better exit when a recovery is removed
Various updating and navigation fixes

Should probably be 2 or 3 PRs. 

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

We had many bugs related to updates, and the back button

So now - when we are on active recovery page

- delete active recovery or guardians - they disappear
- close it -> goes back to main recovery overview screen
- hit back button -> go back to main recovery overview screen

also
- Recovery overview screen updates whenever anything changes. 

Added show active recovery flag to overview - if there is an active recovery, we show it, but only if the user hasn't already claimed it. It's redundant to show when there's already a proxy. 

But a user could in theory remove their proxy without deleting the active recovery so now that works too. 



### 🙈 Screenshots

https://user-images.githubusercontent.com/65412/194477301-604a9284-ae15-49fe-b97b-9133fd0eece1.mov


### 👯‍♀️ Paired with
