### PR TITLE
Feature/reconnect fix

### DIFF
--- a/integration_test/polkadot_repository_test.dart
+++ b/integration_test/polkadot_repository_test.dart
@@ -7,10 +7,6 @@ import '../lib/main.dart' as app;
 
 void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  // InAppLocalhostServer localhostServer = InAppLocalhostServer();
-  // if (!localhostServer.isRunning()) {
-  //   await localhostServer.start();
-  // }
 
   final repository = PolkadotRepository();
 

--- a/lib/datasource/local/flutter_js/substrate_service.dart
+++ b/lib/datasource/local/flutter_js/substrate_service.dart
@@ -15,9 +15,7 @@ class SubstrateService {
   SubstrateChainModel? connectedNode;
   bool _initialized = false;
 
-  void Function(bool isConnected)? connectionStateHandler;
-
-  SubstrateService(this.connectionStateHandler);
+  SubstrateService();
 
   Future<void> init() async {
     print("PolkawalletInit init");
@@ -41,35 +39,32 @@ class SubstrateService {
     return c.future;
   }
 
-  Future<int?> connect() async {
-    print("Substrate Service: CONNECT");
-    if (!_initialized) {
-      throw "you have to initialize the service before connecting";
+  Future<bool> connect() async {
+    try {
+      print("Substrate Service: CONNECT");
+      if (!_initialized) {
+        throw "you have to initialize the service before connecting";
+      }
+
+      /// Connect to a node
+      final res = await webView.connectNode(nodeList);
+
+      _connected = res?.endpoint != null;
+
+      connectedNode = res;
+
+      print("connected: ${res?.endpoint}");
+
+      return _connected;
+    } catch (error) {
+      print("connection failed with exception: $error");
+      _connected = false;
+      return false;
     }
-
-    /// Connect to a node
-    final res = await webView.connectNode(nodeList);
-
-    _connected = res?.endpoint != null;
-    connectionStateHandler?.call(_connected);
-
-    if (res == null) {
-      return null;
-    }
-
-    connectedNode = res;
-
-    print("connected: ${res.endpoint}");
-
-    /// start up the reconnect service
-    startKeepAliveTimer();
-
-    return 0;
   }
 
   Future<void> stop() async {
     print("STOP SERVICE");
-    _keepAliveTimer?.cancel();
     try {
       await webView.evalJavascript('api.disconnect()');
     } catch (error) {
@@ -80,37 +75,7 @@ class SubstrateService {
     _initialized = false;
   }
 
-  DateTime? _lastCheck;
-  Timer? _keepAliveTimer;
-  final int _aliveSeconds = 18;
-
-  /// Keep alive timer accurately reports when the connection is down
-  /// It does not take actions other than calling the connectionStateHandler
-  void startKeepAliveTimer() {
-    _keepAliveTimer = Timer.periodic(const Duration(seconds: 6), (timer) async {
-      final aliveCheckSuccess = await _runAliveCheck();
-      print("alive check $aliveCheckSuccess");
-
-      if (aliveCheckSuccess) {
-        _lastCheck = DateTime.now();
-      } else {
-        /// Alive check failed - we ignore a certain number of failed alive checks
-        if (_lastCheck != null) {
-          print("dead time: ${DateTime.now().difference(_lastCheck!).inSeconds}");
-          if (DateTime.now().difference(_lastCheck!).inSeconds > _aliveSeconds) {
-            print("Network is disconnected");
-            _lastCheck = null;
-            _connected = false;
-            connectionStateHandler?.call(false);
-          } else {
-            print("disconnect detected at ${DateTime.now()} - ignoring...");
-          }
-        }
-      }
-    });
-  }
-
-  Future<bool> _runAliveCheck() async {
+  Future<bool> runAliveCheck() async {
     print("_runAliveCheck");
     try {
       final res = await webView.evalJavascript('api.rpc.system.chain()');

--- a/lib/datasource/local/flutter_js/substrate_service.dart
+++ b/lib/datasource/local/flutter_js/substrate_service.dart
@@ -78,7 +78,11 @@ class SubstrateService {
   Future<bool> runAliveCheck() async {
     print("_runAliveCheck");
     try {
-      final res = await webView.evalJavascript('api.rpc.system.chain()');
+      final future = webView.evalJavascript('api.rpc.system.chain()');
+
+      /// manually time out after 4 seconds - the webView has a 60+ seconds timeout
+      /// this means it does not return in time.
+      final res = await future.timeout(const Duration(seconds: 4));
       print("alive check result: $res");
       if (res == null) {
         print("Alive check fail at ${DateTime.now()}");

--- a/lib/datasource/local/flutter_js/web_view_runner.dart
+++ b/lib/datasource/local/flutter_js/web_view_runner.dart
@@ -227,7 +227,6 @@ class WebViewRunner {
     }
 
     if (!wrapPromise) {
-      print("run raw code: $code");
       final res = await _web!.webViewController.evaluateJavascript(source: code);
       return res;
     }

--- a/lib/datasource/local/flutter_js/web_view_runner.dart
+++ b/lib/datasource/local/flutter_js/web_view_runner.dart
@@ -262,7 +262,7 @@ class WebViewRunner {
       c.completeError("JavaScript Error.");
     }
 
-    return c.future; //.timeout(Duration(seconds: 30));
+    return c.future;
   }
 
   Future<SubstrateChainModel?> connectNode(List<SubstrateChainModel> nodes) async {

--- a/lib/datasource/local/flutter_js/web_view_runner.dart
+++ b/lib/datasource/local/flutter_js/web_view_runner.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:hashed/datasource/local/models/substrate_chain_model.dart';
+import 'package:hashed/domain-shared/app_constants.dart';
 
 extension PlatformExtension on Platform {
   static bool isIos14OrAbove() {
@@ -84,7 +85,7 @@ class WebViewRunner {
       print("creating web view");
       // await _startLocalServer();
       //print("NOT starting web server since we already have inapp web server");
-      final String homeUrl = "http://localhost:8080/assets/polkadot/sdk/assets/index.html";
+      final String homeUrl = "http://localhost:$inappLocalHostPort/assets/polkadot/sdk/assets/index.html";
 
       _web = HeadlessInAppWebView(
         // initialUrlRequest: URLRequest(url: Uri.parse(homeUrl)),
@@ -226,6 +227,7 @@ class WebViewRunner {
     }
 
     if (!wrapPromise) {
+      print("run raw code: $code");
       final res = await _web!.webViewController.evaluateJavascript(source: code);
       return res;
     }
@@ -239,31 +241,48 @@ class WebViewRunner {
     final script = '''
         $code.then(function(res) {
           const finalResult = ${transformer.trim()};
-          console.log(JSON.stringify({ path: "$method", data: finalResult }));finalResult;
+          console.log(JSON.stringify({ path: "$method", data: finalResult }));
+          finalResult + "";
         }).catch(function(err) {
           console.log(JSON.stringify({ path: "$method", error: err.message }));
+          "error";
         });
+        "done";
       ''';
 
     // print("SCRIPT: $script");
+    final res = await _web!.webViewController.evaluateJavascript(source: script);
 
-    _web!.webViewController.evaluateJavascript(source: script);
+    if (res == null) {
+      /// res will be "done" if there is no error and all libraries have been loaded
+      /// res will be null if the script has a JS error and won't even run at all
+      ///
+      /// The latter happens when the libraries are not loaded correctly and for example
+      /// "api" is undefined.
+      ///
+      c.completeError("JavaScript Error.");
+    }
 
-    return c.future;
+    return c.future; //.timeout(Duration(seconds: 30));
   }
 
   Future<SubstrateChainModel?> connectNode(List<SubstrateChainModel> nodes) async {
-    print("connectNode connecting...");
-    final res = await evalJavascript('settings.connect(${jsonEncode(nodes.map((e) => e.endpoint).toList())})');
-    if (res != null) {
-      final index = nodes.indexWhere((e) => e.endpoint.trim() == res.trim());
-      return nodes[index > -1 ? index : 0];
-    } else {
-      print("connectNode failed");
-    }
-    print("connectNode done...");
+    try {
+      print("connectNode connecting...");
+      final res = await evalJavascript('settings.connect(${jsonEncode(nodes.map((e) => e.endpoint).toList())})');
+      if (res != null) {
+        final index = nodes.indexWhere((e) => e.endpoint.trim() == res.trim());
+        return nodes[index > -1 ? index : 0];
+      } else {
+        print("connectNode failed");
+      }
+      print("connectNode done...");
 
-    return null;
+      return null;
+    } catch (error) {
+      print("connectNode error: $error");
+      rethrow;
+    }
   }
 
   Future<void> subscribeMessage(

--- a/lib/domain-shared/app_constants.dart
+++ b/lib/domain-shared/app_constants.dart
@@ -1,9 +1,13 @@
+import 'dart:math';
+
 /// Firebase Dynamic Link Parameters
 const String domainAppUriPrefix = 'https://hashedwallet.page.link';
 const String guardianTargetLink = 'https://app.hashed.io/vouch/?placeholder=&lostAccount=&rescuer=';
 const String androidPacakageName = 'io.hashed.wallet';
 const String iosBundleId = 'io.hashed.wallet';
 const String iosAppStoreId = '1639248612';
+
+int inappLocalHostPort = Random().nextInt(9999) + 10000;
 
 /// Actions
 const String transferAction = 'transfer';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,10 +10,11 @@ import 'package:hashed/datasource/local/member_model_cache_item.dart';
 import 'package:hashed/datasource/local/settings_storage.dart';
 import 'package:hashed/datasource/remote/firebase/firebase_push_notification_service.dart';
 import 'package:hashed/datasource/remote/polkadot_api/polkadot_repository.dart';
+import 'package:hashed/domain-shared/app_constants.dart';
 import 'package:hashed/seeds_app.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
-InAppLocalhostServer localhostServer = InAppLocalhostServer();
+InAppLocalhostServer localhostServer = InAppLocalhostServer(port: inappLocalHostPort);
 
 Future<void> main() async {
   // Zone to handle asynchronous errors (Dart).
@@ -23,7 +24,7 @@ Future<void> main() async {
 
 // we can put this one back in after we got the jaguar one to work
     await localhostServer.start();
-    print("InAppLocalhostServer started");
+    print("InAppLocalhostServer started at $inappLocalHostPort");
 
     await Firebase.initializeApp();
     await settingsStorage.initialise();


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Tested - this reconnect method works. 

Can still be improved but at least it eventually reconnects

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

There were a couple of different factors that made reconnecting difficult and not working:

- The JavaScript engine times out only after 60 seconds when there's a disconnected network. Our alive check runs in 18 seconds so that's an issue
- Restarting would totally hang with JS errors
- JS errors were not propagated correctly - Syntax errors would be caused when the connection failed since there would be no "api" object to refer to. These would not be handled. Now they are handled correctly and the evaluate method returns null when there's a syntax error. 
- Restart was in the substrate service, but the substrate service object would be shut down and recreated. Moved to polkadot service.

### 🙈 Screenshots


### 👯‍♀️ Paired with
